### PR TITLE
Use default crypto context - because creation of new one failing in Docker on linux host

### DIFF
--- a/txpool/types.go
+++ b/txpool/types.go
@@ -40,7 +40,6 @@ type TxParsseConfig struct {
 // TxParseContext is object that is required to parse transactions and turn transaction payload into TxSlot objects
 // usage of TxContext helps avoid extra memory allocations
 type TxParseContext struct {
-	recCtx           *secp256k1.Context // Context for sender recovery
 	keccak1          hash.Hash
 	keccak2          hash.Hash
 	chainId, r, s, v uint256.Int // Signature values
@@ -63,7 +62,6 @@ func NewTxParseContext(chainID uint256.Int) *TxParseContext {
 		withSender: true,
 		keccak1:    sha3.NewLegacyKeccak256(),
 		keccak2:    sha3.NewLegacyKeccak256(),
-		recCtx:     secp256k1.DefaultContext,
 	}
 
 	// behave as of London enabled
@@ -413,7 +411,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	binary.BigEndian.PutUint64(ctx.sig[56:64], ctx.s[0])
 	ctx.sig[64] = vByte
 	// recover sender
-	if _, err = secp256k1.RecoverPubkeyWithContext(ctx.recCtx, ctx.sighash[:], ctx.sig[:], ctx.buf[:0]); err != nil {
+	if _, err = secp256k1.RecoverPubkeyWithContext(secp256k1.DefaultContext, ctx.sighash[:], ctx.sig[:], ctx.buf[:0]); err != nil {
 		return 0, fmt.Errorf("%s: recovering sender from signature: %w", ParseTransactionErrorPrefix, err)
 	}
 	//apply keccak to the public key


### PR DESCRIPTION
error: 
```
erigon_1      | fatal: morestack on g0
erigon_1      | SIGTRAP: trace trap
erigon_1      | PC=0x4a7002 m=10 sigcode=128
erigon_1      |
erigon_1      | goroutine 0 [idle]:
erigon_1      | runtime.abort()
erigon_1      | 	runtime/asm_amd64.s:854 +0x2
erigon_1      | runtime.morestack()
erigon_1      | 	runtime/asm_amd64.s:425 +0x25
erigon_1      |
erigon_1      | goroutine 1 [syscall]:
erigon_1      | runtime.cgocall(0x120d840, 0xc00176dd80, 0xc00176dd90)
erigon_1      | 	runtime/cgocall.go:154 +0x5b fp=0xc00176dd50 sp=0xc00176dd18 pc=0x43813b
erigon_1      | github.com/ledgerwatch/secp256k1._Cfunc_secp256k1_context_create_sign_verify(0x0)
erigon_1      | 	_cgo_gotypes.go:155 +0x45 fp=0xc00176dd80 sp=0xc00176dd50 pc=0x9652e5
erigon_1      | github.com/ledgerwatch/secp256k1.initContext(0x15773a0)
erigon_1      | 	github.com/ledgerwatch/secp256k1@v0.0.0-20210626115225-cd5cd00ed72d/secp256.go:74 +0x25 fp=0xc00176dda0 sp=0xc00176dd80 pc=0x968165
erigon_1      | github.com/ledgerwatch/secp256k1.NewContext(...)
erigon_1      | 	github.com/ledgerwatch/secp256k1@v0.0.0-20210626115225-cd5cd00ed72d/secp256.go:89
erigon_1      | github.com/ledgerwatch/erigon-lib/txpool.NewTxParseContext(0x1, 0x0, 0x0, 0x0, 0xc0009a2000)
```