### PR TITLE
Compress: add maxPatternLen=64

### DIFF
--- a/compress/compress.go
+++ b/compress/compress.go
@@ -87,7 +87,7 @@ const maxPatternLen = 64
 
 // maxDictPatterns is the maximum number of patterns allowed in the initial (not reduced dictionary)
 // Large values increase memory consumption of dictionary reduction phase
-const maxDictPatterns = 1024 * 1024
+const maxDictPatterns = 2 * 1024 * 1024
 
 //nolint
 const compressLogPrefix = "compress"

--- a/compress/compress.go
+++ b/compress/compress.go
@@ -83,6 +83,7 @@ const superstringLimit = 16 * 1024 * 1024
 
 // minPatternLen is minimum length of pattern we consider to be included into the dictionary
 const minPatternLen = 5
+const maxPatternLen = 64
 
 // maxDictPatterns is the maximum number of patterns allowed in the initial (not reduced dictionary)
 // Large values increase memory consumption of dictionary reduction phase
@@ -1120,7 +1121,7 @@ func (c *Compressor) processSuperstring() error {
 			continue
 		}
 		for l := c.lcp[i]; l > c.lcp[i+1]; l-- {
-			if l < minPatternLen {
+			if l < minPatternLen || l > maxPatternLen {
 				continue
 			}
 			// Go back


### PR DESCRIPTION
if set limit maxPatternLen lower - then can increase maxDictPatterns - because dictionary is not bloated by large permutations