### PR TITLE
[beta] RLP: Values in [0, 128) must be encoded as single byte

### DIFF
--- a/rlp/parse.go
+++ b/rlp/parse.go
@@ -59,6 +59,9 @@ func Prefix(payload []byte, pos int) (dataPos int, dataLen int, isList bool, err
 		dataPos = pos + 1
 		dataLen = int(first) - 128
 		isList = false
+		if dataLen == 1 && dataPos < len(payload) && payload[dataPos] < 128 {
+			err = fmt.Errorf("rlp: non-canonical size information")
+		}
 	case first < 192:
 		// If a string is more than 55 bytes long, the
 		// RLP encoding consists of a single byte with value 0xB7 plus the length
@@ -72,7 +75,6 @@ func Prefix(payload []byte, pos int) (dataPos int, dataLen int, isList bool, err
 		isList = false
 		if dataLen < 56 {
 			err = fmt.Errorf("rlp: non-canonical size information")
-			break
 		}
 	case first < 248:
 		// isList of len < 56
@@ -97,7 +99,6 @@ func Prefix(payload []byte, pos int) (dataPos int, dataLen int, isList bool, err
 		isList = true
 		if dataLen < 56 {
 			err = fmt.Errorf("rlp: non-canonical size information")
-			break
 		}
 	}
 	if err == nil {
@@ -193,7 +194,7 @@ func U256(payload []byte, pos int, x *uint256.Int) (int, error) {
 		return 0, err
 	}
 	if dataLen > 32 {
-		return 0, fmt.Errorf("uint256 must not be more than 8 bytes long, got %d", dataLen)
+		return 0, fmt.Errorf("uint256 must not be more than 32 bytes long, got %d", dataLen)
 	}
 	if dataLen > 0 && payload[dataPos] == 0 {
 		return 0, fmt.Errorf("integer encoding for RLP must not have leading zeros: %x", payload[dataPos:dataPos+dataLen])

--- a/rlp/parse_test.go
+++ b/rlp/parse_test.go
@@ -2,9 +2,11 @@ package rlp
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,6 +26,11 @@ var parseU64Tests = []struct {
 }{
 	{payload: decodeHex("820400"), expectPos: 3, expectRes: 1024},
 	{payload: decodeHex("07"), expectPos: 1, expectRes: 7},
+	{payload: decodeHex("8107"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("B8020004"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("C0"), expectErr: errors.New("uint64 must be a string, not isList")},
+	{payload: decodeHex("00"), expectErr: errors.New("integer encoding for RLP must not have leading zeros: 00")},
+	{payload: decodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectErr: errors.New("uint64 must not be more than 8 bytes long, got 10")},
 }
 
 var parseU32Tests = []struct {
@@ -34,6 +41,29 @@ var parseU32Tests = []struct {
 }{
 	{payload: decodeHex("820400"), expectPos: 3, expectRes: 1024},
 	{payload: decodeHex("07"), expectPos: 1, expectRes: 7},
+	{payload: decodeHex("8107"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("B8020004"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("C0"), expectErr: errors.New("uint32 must be a string, not isList")},
+	{payload: decodeHex("00"), expectErr: errors.New("integer encoding for RLP must not have leading zeros: 00")},
+	{payload: decodeHex("85FF6738FF7C"), expectErr: errors.New("uint32 must not be more than 4 bytes long, got 5")},
+}
+
+var parseU256Tests = []struct {
+	payload   []byte
+	expectPos int
+	expectRes *uint256.Int
+	expectErr error
+}{
+	{payload: decodeHex("8BFFFFFFFFFFFFFFFFFF7C"), expectErr: errors.New("unexpected end of payload")},
+	{payload: decodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectPos: 11, expectRes: new(uint256.Int).SetBytes(decodeHex("FFFFFFFFFFFFFFFFFF7C"))},
+	{payload: decodeHex("85CE05050505"), expectPos: 6, expectRes: new(uint256.Int).SetUint64(0xCE05050505)},
+	{payload: decodeHex("820400"), expectPos: 3, expectRes: new(uint256.Int).SetUint64(1024)},
+	{payload: decodeHex("07"), expectPos: 1, expectRes: new(uint256.Int).SetUint64(7)},
+	{payload: decodeHex("8107"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("B8020004"), expectErr: errors.New("rlp: non-canonical size information")},
+	{payload: decodeHex("C0"), expectErr: errors.New("must be a string, instead of a list")},
+	{payload: decodeHex("00"), expectErr: errors.New("integer encoding for RLP must not have leading zeros: 00")},
+	{payload: decodeHex("A101000000000000000000000000000000000000008B000000000000000000000000"), expectErr: errors.New("uint256 must not be more than 32 bytes long, got 33")},
 }
 
 func TestPrimitives(t *testing.T) {
@@ -41,7 +71,7 @@ func TestPrimitives(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			assert := assert.New(t)
 			pos, res, err := U64(tt.payload, 0)
-			assert.NoError(err)
+			assert.Equal(tt.expectErr, err)
 			assert.Equal(tt.expectPos, pos)
 			assert.Equal(tt.expectRes, res)
 		})
@@ -50,9 +80,21 @@ func TestPrimitives(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			assert := assert.New(t)
 			pos, res, err := U32(tt.payload, 0)
-			assert.NoError(err)
+			assert.Equal(tt.expectErr, err)
 			assert.Equal(tt.expectPos, pos)
 			assert.Equal(tt.expectRes, res)
+		})
+	}
+	for i, tt := range parseU256Tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			assert := assert.New(t)
+			res := new(uint256.Int)
+			pos, err := U256(tt.payload, 0, res)
+			assert.Equal(tt.expectErr, err)
+			assert.Equal(tt.expectPos, pos)
+			if err == nil {
+				assert.Equal(tt.expectRes, res)
+			}
 		})
 	}
 }


### PR DESCRIPTION
* RLP: Values in [0, 128) must be encoded as single byte

* Fix error message