### PR TITLE
Update PriceBump, change tx replacement logic, update test

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -968,7 +968,7 @@ func (p *TxPool) addLocked(mt *metaTx) DiscardReason {
 	if found != nil {
 		tipThreshold := found.Tx.tip * (100 + p.cfg.PriceBump) / 100
 		feecapThreshold := found.Tx.feeCap * (100 + p.cfg.PriceBump) / 100
-		if mt.Tx.tip <= tipThreshold || mt.Tx.feeCap <= feecapThreshold {
+		if mt.Tx.tip < tipThreshold || mt.Tx.feeCap < feecapThreshold {
 			// Both tip and feecap need to be larger than previously to replace the transaction
 			return NotReplaced
 		}

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -285,16 +285,36 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(uint64(3), nonce)
 	}
-	// Bumped only tip and feeCap by 10%, tx accepted
+	// Bumped only tip, transaction not accepted
 	{
 		txSlots := TxSlots{}
 		txSlot := &TxSlot{
-			tip:    330001,
-			feeCap: 330001,
+			tip:    3000000,
+			feeCap: 300000,
 			gas:    100000,
 			nonce:  3,
 		}
 		txSlot.IdHash[0] = 3
+		txSlots.Append(txSlot, addr[:], true)
+		reasons, err := pool.AddLocalTxs(ctx, txSlots)
+		assert.NoError(err)
+		for _, reason := range reasons {
+			assert.Equal(NotReplaced, reason, reason.String())
+		}
+		nonce, ok := pool.NonceFromAddress(addr)
+		assert.True(ok)
+		assert.Equal(uint64(3), nonce)
+	}
+	// Bumped both tip and feeCap by 10%, tx accepted
+	{
+		txSlots := TxSlots{}
+		txSlot := &TxSlot{
+			tip:    330000,
+			feeCap: 330000,
+			gas:    100000,
+			nonce:  3,
+		}
+		txSlot.IdHash[0] = 4
 		txSlots.Append(txSlot, addr[:], true)
 		reasons, err := pool.AddLocalTxs(ctx, txSlots)
 		assert.NoError(err)


### PR DESCRIPTION
A transaction can be replaced by another one whose tip and feeCap are equal to threshold in Go-Ethereum. Can we keep the same logic with Go-Ethereum?

https://github.com/ethereum/go-ethereum/blob/356bbe343a30789e77bb38f25983c8f2f2bfbb47/core/tx_list.go#L301-L303
```go
if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
	return false, nil
}
```