### PR TITLE
computeCommitment exiting with RootHash when there are no updates

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -2280,6 +2280,11 @@ func (w *Writer) computeCommitment(trace bool) ([]byte, error) {
 		j++
 		return true
 	})
+
+	if len(updates) == 0 {
+		return w.a.hph.RootHash()
+	}
+
 	w.a.hph.Reset()
 	w.a.hph.ResetFns(w.branchFn, w.accountFn, w.storageFn, w.lockFn, w.unlockFn)
 	w.a.hph.SetTrace(trace)
@@ -2330,6 +2335,7 @@ func (w *Writer) computeCommitment(trace bool) ([]byte, error) {
 			}
 		}
 	}
+
 	var rootHash []byte
 	if rootHash, err = w.a.hph.RootHash(); err != nil {
 		return nil, err

--- a/commitment/hex_patricia_hashed.go
+++ b/commitment/hex_patricia_hashed.go
@@ -27,9 +27,10 @@ import (
 	"strings"
 
 	"github.com/holiman/uint256"
+	"golang.org/x/crypto/sha3"
+
 	"github.com/ledgerwatch/erigon-lib/common/length"
 	"github.com/ledgerwatch/erigon-lib/rlp"
-	"golang.org/x/crypto/sha3"
 )
 
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports


### PR DESCRIPTION
#257 
Here if there are no updates, commitment finishes execution by evaluating rootHash without Resetting `HexPatriciaHasher`.