### PR TITLE
Fix aggregator.go: OpenFile permission

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -226,7 +226,7 @@ func (cf *ChangeFile) openFile(blockNum uint64, write bool) error {
 		cf.path = filepath.Join(cf.dir, fmt.Sprintf("%s.%d-%d.chg", cf.namebase, startBlock, endBlock))
 		var err error
 		if write {
-			if cf.file, err = os.OpenFile(cf.path, os.O_RDWR|os.O_CREATE, 0o755); err != nil {
+			if cf.file, err = os.OpenFile(cf.path, os.O_RDWR|os.O_CREATE, 0755); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
https://github.com/ledgerwatch/erigon-lib/blob/83951a1d625c3eec96f5d0f21917a38d24996541/aggregator/aggregator.go#L229

`0o755` should be `0755`