### PR TITLE
Add LastForkchoice table

### DIFF
--- a/kv/tables.go
+++ b/kv/tables.go
@@ -298,10 +298,8 @@ const (
 
 	HeadHeaderKey = "LastHeader"
 
-	// https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/specification.md#forkchoicestatev1
-	ForkchoiceHead      = "ForkchoiceHead"      // headBlockHash
-	ForkchoiceSafe      = "ForkchoiceSafe"      // safeBlockHash
-	ForkchoiceFinalized = "ForkchoiceFinalized" // finalizedBlockHash
+	// headBlockHash, safeBlockHash, finalizedBlockHash of the latest Engine API forkchoice
+	LastForkchoice = "LastForkchoice"
 
 	// TransitionBlockKey tracks the last proof-of-work block
 	TransitionBlockKey = "TransitionBlock"
@@ -385,6 +383,7 @@ var ChaindataTables = []string{
 	Senders,
 	HeadBlockKey,
 	HeadHeaderKey,
+	LastForkchoice,
 	Migrations,
 	LogTopicIndex,
 	LogAddressIndex,
@@ -416,9 +415,6 @@ var ChaindataTables = []string{
 	BorReceipts,
 	BorTxLookup,
 	BorSeparate,
-	ForkchoiceHead,
-	ForkchoiceSafe,
-	ForkchoiceFinalized,
 }
 
 const (

--- a/kv/tables.go
+++ b/kv/tables.go
@@ -296,6 +296,13 @@ const (
 	// headBlockKey tracks the latest know full block's hash.
 	HeadBlockKey = "LastBlock"
 
+	HeadHeaderKey = "LastHeader"
+
+	// https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/specification.md#forkchoicestatev1
+	ForkchoiceHead      = "ForkchoiceHead"      // headBlockHash
+	ForkchoiceSafe      = "ForkchoiceSafe"      // safeBlockHash
+	ForkchoiceFinalized = "ForkchoiceFinalized" // finalizedBlockHash
+
 	// TransitionBlockKey tracks the last proof-of-work block
 	TransitionBlockKey = "TransitionBlock"
 
@@ -304,8 +311,7 @@ const (
 	// in case of bug-report developer can ask content of this bucket
 	Migrations = "Migration"
 
-	Sequence      = "Sequence" // tbl_name -> seq_u64
-	HeadHeaderKey = "LastHeader"
+	Sequence = "Sequence" // tbl_name -> seq_u64
 
 	Epoch        = "DevEpoch"        // block_num_u64+block_hash->transition_proof
 	PendingEpoch = "DevPendingEpoch" // block_num_u64+block_hash->transition_proof
@@ -410,6 +416,9 @@ var ChaindataTables = []string{
 	BorReceipts,
 	BorTxLookup,
 	BorSeparate,
+	ForkchoiceHead,
+	ForkchoiceSafe,
+	ForkchoiceFinalized,
 }
 
 const (

--- a/kv/tables.go
+++ b/kv/tables.go
@@ -295,8 +295,10 @@ const (
 
 	// headBlockKey tracks the latest know full block's hash.
 	HeadBlockKey = "LastBlock"
+
 	// TransitionBlockKey tracks the last proof-of-work block
 	TransitionBlockKey = "TransitionBlock"
+
 	// migrationName -> serialized SyncStageProgress and SyncStageUnwind buckets
 	// it stores stages progress to understand in which context was executed migration
 	// in case of bug-report developer can ask content of this bucket
@@ -390,7 +392,6 @@ var ChaindataTables = []string{
 	Sequence,
 	EthTx,
 	NonCanonicalTxs,
-	TransitionBlockKey,
 	TrieOfAccounts,
 	TrieOfStorage,
 	HashedAccounts,
@@ -427,6 +428,7 @@ var SentryTables = []string{}
 // ChaindataDeprecatedTables - list of buckets which can be programmatically deleted - for example after migration
 var ChaindataDeprecatedTables = []string{
 	Clique,
+	TransitionBlockKey,
 }
 
 type CmpFunc func(k1, k2, v1, v2 []byte) int


### PR DESCRIPTION
Add LastForkchoice table to track head/safe/finalized BlockHash of the last [forkchoice](https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/specification.md#forkchoicestatev1).

Also deprecate unused TransitionBlock table.