### PR TITLE
shorter common.ByteCount for shorter logs

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -21,14 +21,14 @@ import "fmt"
 func ByteCount(b uint64) string {
 	const unit = 1024
 	if b < unit {
-		return fmt.Sprintf("%d B", b)
+		return fmt.Sprintf("%db", b)
 	}
 	div, exp := uint64(unit), 0
 	for n := b / unit; n >= unit; n /= unit {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f %ciB",
+	return fmt.Sprintf("%.1f%cb",
 		float64(b)/float64(div), "KMGTPE"[exp])
 }
 


### PR DESCRIPTION
change:
``` 
alloc="7.56 GiB" sys="14.98 GiB"
alloc=7.56Gb sys=14.98Gb
```