### PR TITLE
commitment: fixed hash evaluation for hex patricia trie

### DIFF
--- a/commitment/hex_patricia_hashed.go
+++ b/commitment/hex_patricia_hashed.go
@@ -670,9 +670,11 @@ func (hph *HexPatriciaHashed) computeCellHash(cell *Cell, depth int, buf []byte)
 			if hph.trace {
 				fmt.Printf("leafHashWithKeyVal(singleton) for [%x]=>[%x]\n", cell.downHashedKey[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen])
 			}
-			if _, err = hph.leafHashWithKeyVal(storageRootHash[:0], cell.downHashedKey[:64-hashedKeyOffset+1], rlp.RlpSerializableBytes(cell.Storage[:cell.StorageLen]), true); err != nil {
+			aux := make([]byte, 0, 33)
+			if aux, err = hph.leafHashWithKeyVal(aux, cell.downHashedKey[:64-hashedKeyOffset+1], rlp.RlpSerializableBytes(cell.Storage[:cell.StorageLen]), true); err != nil {
 				return nil, err
 			}
+			storageRootHash = *(*[length.Hash]byte)(aux[1:])
 			storageRootHashIsSet = true
 		} else {
 			if hph.trace {


### PR DESCRIPTION
Bug led to rootHash mismatch with etalon value. 