### PR TITLE
[txpool] Prevent clogging up the pending sub pool

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -623,6 +623,7 @@ func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx) error {
 			return err
 		}
 		if len(rlpTx) == 0 {
+			fmt.Printf("Skipped tx because it is empty: [%x]\n", best.ms[i].Tx.IDHash)
 			continue
 		}
 		txs.Txs[j] = rlpTx

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -1334,9 +1334,13 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 			return
 		case <-logEvery.C:
 			var txs types.TxsRlp
-			db.View(ctx, func(tx kv.Tx) error {
+			if err := db.View(ctx, func(tx kv.Tx) error {
 				return p.Best(200, &txs, tx)
-			})
+			}); err != nil {
+				fmt.Printf("Error Best: %v\n", err)
+			} else {
+				fmt.Printf("Best(200) returned %d txs\n", len(txs.Txs))
+			}
 			p.logStats()
 		case <-processRemoteTxsEvery.C:
 			if !p.Started() {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -1114,9 +1114,9 @@ func removeMined(byNonce *BySenderAndNonce, minedTxs []*types.TxSlot, pending *P
 			if mt.Tx.Nonce > nonce {
 				return false
 			}
-			if mt.Tx.Traced {
-				log.Info(fmt.Sprintf("TX TRACING: removeMined idHash=%x senderId=%d, currentSubPool=%s", mt.Tx.IDHash, mt.Tx.SenderID, mt.currentSubPool))
-			}
+			//if mt.Tx.Traced {
+			log.Info(fmt.Sprintf("TX TRACING: removeMined idHash=%x senderId=%d, currentSubPool=%s", mt.Tx.IDHash, mt.Tx.SenderID, mt.currentSubPool))
+			//}
 			toDel = append(toDel, mt)
 			// del from sub-pool
 			switch mt.currentSubPool {


### PR DESCRIPTION
Over time, due to timings of arrival of transactions and notifications about new blocks, transactions accumulate in all the pools that should have been removed