### PR TITLE
Fixup for a possible deadlock if db.env.BeginTxn fails

### DIFF
--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -401,6 +401,9 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	defer func() {
 		if err == nil {
 			db.wg.Add(1)
+		} else {
+			// on error, we need to free up the limiter slot
+			<-db.roTxsLimiter
 		}
 	}()
 

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -401,8 +401,10 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	defer func() {
 		if err == nil {
 			db.wg.Add(1)
-		} else {
-			// on error, we need to free up the limiter slot
+		}
+		if txn == nil {
+			// on error, or if there is whatever reason that we don't return a tx,
+			// we need to free up the limiter slot, otherwise it could lead to deadlocks
 			<-db.roTxsLimiter
 		}
 	}()


### PR DESCRIPTION
We never released the semaphore if `db.env.BeginTxn` failed, that could lead to saturation of this semaphore and block all transactions to the DB.