### PR TITLE
check if we deleted the entry

### DIFF
--- a/kv/memdb/memory_mutation.go
+++ b/kv/memdb/memory_mutation.go
@@ -223,6 +223,15 @@ func (m *MemoryMutation) Delete(table string, k, v []byte) error {
 	return nil
 }
 
+// puts an entry into deleted entries map assuring deletion in flush
+func (m *MemoryMutation) DeleteEntry(table string, k []byte) {
+	if _, ok := m.deletedEntries[table]; !ok {
+		m.deletedEntries[table] = make(map[string]struct{})
+	}
+
+	m.deletedEntries[table][string(k)] = struct{}{}
+}
+
 func (m *MemoryMutation) Commit() error {
 	return nil
 }


### PR DESCRIPTION
Currently we add the key into the deletedEntry map and then attempt to delete the entry. A problem comes up if we attempt to delete a key with the wrong value, since it would ultimately not delete the entry. Even though we didn't delete the entry we add it into our deletedEntry map, so it gets fully deleted inside of `Flush`