### PR TITLE
Idempotent (*PendingPool) Remove

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2069,6 +2069,7 @@ func (p *PendingPool) Len() int { return len(p.best.ms) }
 func (p *PendingPool) Remove(i *metaTx) {
 	heap.Remove(p.worst, i.worstIndex)
 	p.best.UnsafeRemove(i)
+	i.currentSubPool = 0
 }
 
 func (p *PendingPool) Add(i *metaTx) {


### PR DESCRIPTION
0 `currentSubPool` means that the transaction is already removed. `(*SubPool) Remove` already sets `currentSubPool` to 0.

Hopefully this should fix the following error observed on a Ropsten node:
```
panic: runtime error: index out of range [-1]

goroutine 3225 [running]:
github.com/ledgerwatch/erigon-lib/txpool.(*bestSlice).Swap(...)
    github.com/ledgerwatch/erigon-lib@v0.0.0-20220719040828-9ceeeac385ad/txpool/pool.go:2025
github.com/ledgerwatch/erigon-lib/txpool.(*bestSlice).UnsafeRemove(...)
```
Here is the full log:
[alloc_logs_erigon.stderr_3.0.txt](https://github.com/ledgerwatch/erigon-lib/files/9141628/alloc_logs_erigon.stderr_3.0.txt)
