### PR TITLE
compress: implemented consensed huffman pattern tables

### DIFF
--- a/compress/decompress.go
+++ b/compress/decompress.go
@@ -138,10 +138,13 @@ type Decompressor struct {
 }
 
 // Tables with bitlen greater than threshold will be condensed.
-// To disable condesning at all use 9 (we dont use tables larger than 2^9)
-// To enable condensing for tables > 64 set to 6
-// Condensing reduces memory consumption but co
-// Should be set before calling NewDecompression
+// Condensing reduces size of decompression table but leads to slower reads.
+// To disable condesning at all set to 9 (we dont use tables larger than 2^9)
+// To enable condensing for tables of size larger 64 = 6
+//					 					  for all tables               = 0
+// There is no sense to condense tables of size [1 - 64] in terms of performance
+//
+// Should be set before calling NewDecompression.
 var condensePatternTableBitThreshold = 9
 
 func SetDecompressionTableCondensity(fromBitSize int) {

--- a/compress/decompress.go
+++ b/compress/decompress.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon-lib/mmap"
-	"github.com/ledgerwatch/log/v3"
 )
 
 type word []byte // plain text word associated with code from dictionary
@@ -141,7 +142,7 @@ type Decompressor struct {
 // Condensing reduces size of decompression table but leads to slower reads.
 // To disable condesning at all set to 9 (we dont use tables larger than 2^9)
 // To enable condensing for tables of size larger 64 = 6
-//					 					  for all tables               = 0
+// for all tables                                    = 0
 // There is no sense to condense tables of size [1 - 64] in terms of performance
 //
 // Should be set before calling NewDecompression.

--- a/compress/decompress_bench_test.go
+++ b/compress/decompress_bench_test.go
@@ -75,13 +75,14 @@ func BenchmarkDecompressMatchPrefix(b *testing.B) {
 func BenchmarkDecompressTorrent(t *testing.B) {
 	t.Skip()
 
-	// fpath := "./v1-000500-001000-transactions.seg"
-	// fpath := "./v1-004000-004500-transactions.seg"
-	// fpath := "./v1-005500-006000-transactions.seg"
+	// fpath := "/mnt/data/chains/mainnet/snapshots/v1-014000-014500-transactions.seg"
 	fpath := "./v1-006000-006500-transactions.seg"
 	st, err := os.Stat(fpath)
 	require.NoError(t, err)
-	fmt.Printf("stat: %+v %dbytes\n", st.Name(), st.Size())
+	fmt.Printf("file: %v, size: %d\n", st.Name(), st.Size())
+
+	condensePatternTableBitThreshold = 6
+	fmt.Printf("bit threshold: %d\n", condensePatternTableBitThreshold)
 
 	d, err := NewDecompressor(fpath)
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func BenchmarkDecompressTorrent(t *testing.B) {
 
 	getter := d.MakeGetter()
 
-	for i := 0; i < t.N; i++ {
+	for i := 0; i < t.N && getter.HasNext(); i++ {
 		_, sz := getter.Next(nil)
 		if sz == 0 {
 			t.Fatal("sz == 0")

--- a/compress/decompress_test.go
+++ b/compress/decompress_test.go
@@ -211,14 +211,15 @@ Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserun
 var loremStrings = strings.Split(lorem, " ")
 
 func TestDecompressTorrent(t *testing.T) {
-	// t.Skip()
+	t.Skip()
 
-	fpath := "./v1-006000-006500-transactions.seg"
-	// fpath := "./v1-000000-000500-transactions.seg"
+	fpath := "/mnt/data/chains/mainnet/snapshots/v1-014000-014500-transactions.seg"
 	st, err := os.Stat(fpath)
 	require.NoError(t, err)
-	fmt.Printf("stat: %+v\n", st)
+	fmt.Printf("file: %v, size: %d\n", st.Name(), st.Size())
 
+	condensePatternTableBitThreshold = 9
+	fmt.Printf("bit threshold: %d\n", condensePatternTableBitThreshold)
 	d, err := NewDecompressor(fpath)
 
 	require.NoError(t, err)

--- a/compress/decompress_test.go
+++ b/compress/decompress_test.go
@@ -211,9 +211,10 @@ Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserun
 var loremStrings = strings.Split(lorem, " ")
 
 func TestDecompressTorrent(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 
-	fpath := "./v1-006000-006500-transactions.seg"
+	// fpath := "./v1-006000-006500-transactions.seg"
+	fpath := "./v1-000000-000500-transactions.seg"
 	st, err := os.Stat(fpath)
 	require.NoError(t, err)
 	fmt.Printf("stat: %+v\n", st)
@@ -223,9 +224,11 @@ func TestDecompressTorrent(t *testing.T) {
 	defer d.Close()
 
 	getter := d.MakeGetter()
+	_ = getter
 
-	for getter.HasNext() {
-		_, sz := getter.Next(nil)
-		require.NotZero(t, sz)
-	}
+	// for getter.HasNext() {
+	// 	buf, sz := getter.Next(nil)
+	// 	fmt.Printf("%x\n", buf)
+	// 	require.NotZero(t, sz)
+	// }
 }

--- a/compress/decompress_test.go
+++ b/compress/decompress_test.go
@@ -213,22 +213,23 @@ var loremStrings = strings.Split(lorem, " ")
 func TestDecompressTorrent(t *testing.T) {
 	// t.Skip()
 
-	// fpath := "./v1-006000-006500-transactions.seg"
-	fpath := "./v1-000000-000500-transactions.seg"
+	fpath := "./v1-006000-006500-transactions.seg"
+	// fpath := "./v1-000000-000500-transactions.seg"
 	st, err := os.Stat(fpath)
 	require.NoError(t, err)
 	fmt.Printf("stat: %+v\n", st)
 
 	d, err := NewDecompressor(fpath)
+
 	require.NoError(t, err)
 	defer d.Close()
 
 	getter := d.MakeGetter()
 	_ = getter
 
-	// for getter.HasNext() {
-	// 	buf, sz := getter.Next(nil)
-	// 	fmt.Printf("%x\n", buf)
-	// 	require.NotZero(t, sz)
-	// }
+	for getter.HasNext() {
+		_, sz := getter.Next(nil)
+		// fmt.Printf("%x\n", buf)
+		require.NotZero(t, sz)
+	}
 }


### PR DESCRIPTION
Optionally added ability to condense pattern tables to reduce required amount of RAM.
By default condensing is disabled for the sake of faster decompression.
To set condensing of tables larger than 64 elements needed to call  

`compression.SetDecompressionTableCondensity(fromBitSize int)` with `fromBitSize` = 6. Set to 9 to totally disable condensing (since we don't use tables larger than 2^9) 

before calling `NewDecompressor(compressedFilePath)`
