### PR TITLE
Revert change to (*PendingPool) EnforceBestInvariants()

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"sort"
 	"sync"
 	"time"
 
@@ -48,7 +49,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/types"
 	"github.com/ledgerwatch/log/v3"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -2041,7 +2041,7 @@ func (p *PendingPool) EnforceWorstInvariants() {
 	heap.Init(p.worst)
 }
 func (p *PendingPool) EnforceBestInvariants() {
-	slices.SortFunc(p.best.ms, func(i, j *metaTx) bool { return i.better(j, p.best.pendingBaseFee) })
+	sort.Sort(p.best)
 }
 
 func (p *PendingPool) Best() *metaTx { //nolint


### PR DESCRIPTION
Apparently it causes 
```
[INFO] [07-20|06:49:12.961] RPC Daemon notified of new headers       from=12628993 to=12628994 header sending=10.264µs log sending=503ns
panic: runtime error: index out of range [-1]

goroutine 4539 [running]:
github.com/ledgerwatch/erigon-lib/txpool.(*bestSlice).Swap(...)
    github.com/ledgerwatch/erigon-lib@v0.0.0-20220719140506-af5355ee9286/txpool/pool.go:2025
github.com/ledgerwatch/erigon-lib/txpool.(*bestSlice).UnsafeRemove(...)
```

This partially reverts https://github.com/ledgerwatch/erigon-lib/commit/ebea2863c12c90537b6dc546b3bf6588cbd2f96d