### PR TITLE
Fix for a lot of pending transactions being dropped from newPendingTransactions 

### DIFF
--- a/types/txn.go
+++ b/types/txn.go
@@ -501,9 +501,7 @@ func (h Hashes) DedupCopy() Hashes {
 	dest := length.Hash
 	for i := dest; i < len(h); i += length.Hash {
 		if !bytes.Equal(h[i:i+length.Hash], h[i-length.Hash:i]) {
-			if dest != i {
-				copy(c[dest:dest+length.Hash], h[i:i+length.Hash])
-			}
+			copy(c[dest:dest+length.Hash], h[i:i+length.Hash])
 			dest += length.Hash
 		}
 	}

--- a/types/txn_test.go
+++ b/types/txn_test.go
@@ -91,8 +91,40 @@ func TestDedupHashes(t *testing.T) {
 	assert := assert.New(t)
 	h := toHashes(2, 6, 2, 5, 2, 4)
 	c := h.DedupCopy()
+	assert.Equal(6, h.Len())
 	assert.Equal(4, c.Len())
+	assert.Equal(toHashes(2, 2, 2, 4, 5, 6), h)
 	assert.Equal(toHashes(2, 4, 5, 6), c)
+
+	h = toHashes(2, 2)
+	c = h.DedupCopy()
+	assert.Equal(toHashes(2, 2), h)
+	assert.Equal(toHashes(2), c)
+
+	h = toHashes(1)
+	c = h.DedupCopy()
+	assert.Equal(1, h.Len())
+	assert.Equal(1, c.Len())
+	assert.Equal(toHashes(1), h)
+	assert.Equal(toHashes(1), c)
+
+	h = toHashes()
+	c = h.DedupCopy()
+	assert.Equal(0, h.Len())
+	assert.Equal(0, c.Len())
+	assert.Equal(0, len(h))
+	assert.Equal(0, len(c))
+
+	h = toHashes(1, 2, 3, 4)
+	c = h.DedupCopy()
+	assert.Equal(toHashes(1, 2, 3, 4), h)
+	assert.Equal(toHashes(1, 2, 3, 4), c)
+
+	h = toHashes(4, 2, 1, 3)
+	c = h.DedupCopy()
+	assert.Equal(toHashes(1, 2, 3, 4), h)
+	assert.Equal(toHashes(1, 2, 3, 4), c)
+
 }
 
 func toHashes(h ...byte) (out Hashes) {


### PR DESCRIPTION
This fixes the issue where a lot of new pending transactions are dropped from being pushed to the subscriber.

Related issues on Erigon are:
https://github.com/ledgerwatch/erigon/issues/3373
https://github.com/ledgerwatch/erigon/issues/3892 

The problem occurs here: https://github.com/ledgerwatch/erigon-lib/blob/main/txpool/pool.go#L1379

Say `h` had 5 transaction hashes, all unique.
After `h = h.DedupCopy()`, `h.Len()` is still 5, but only h.At(0) has an actual tx address, while all the rest will be 0x0.
This results in only one transaction hash being pushed to the subscriber of `newPendingTransactions`.
Effectively, this issue was throttling push of new pending transactions to at most 1 per 100ms (the default remote txs handling interval).  On active networks such as Ethereum mainnet, this causes a lot of new pending transactions to be missed by the subscriber client.

I observed the bug on v2022.04.05 on Ethereum mainnet, and verified the fix by applying the fix locally to erigon-lib v0.0.0-20220415095037-bce96ae8d117.  Now I am getting a lot more new pending transactions from `newPendingTransactions` subscription.