### PR TITLE
Make Delete() remove all values for DupSort tables

### DIFF
--- a/kv/mdbx/kv_mdbx_test.go
+++ b/kv/mdbx/kv_mdbx_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -528,4 +529,25 @@ func TestCurrentDup(t *testing.T) {
 
 	require.Equal(t, []string{"key1", "key1"}, keys)
 	require.Equal(t, []string{"value1.1", "value1.3"}, values)
+}
+
+func TestDupDelete(t *testing.T) {
+	db, tx, c := BaseCase(t)
+	defer db.Close()
+	defer tx.Rollback()
+	defer c.Close()
+
+	k, _, err := c.Current()
+	require.Nil(t, err)
+	require.Equal(t, []byte("key3"), k)
+
+	err = c.DeleteCurrentDuplicates()
+	require.Nil(t, err)
+
+	err = c.Delete([]byte("key1"))
+	require.Nil(t, err)
+
+	count, err := c.Count()
+	require.Nil(t, err)
+	assert.Zero(t, count)
 }

--- a/kv/memdb/memory_mutation.go
+++ b/kv/memdb/memory_mutation.go
@@ -379,5 +379,5 @@ func (m *MemoryMutation) ViewID() uint64 {
 }
 
 func (m *MemoryMutation) Reset() error {
-	return nil
+	panic("MemoryMutation.Reset not implemented")
 }


### PR DESCRIPTION
Now Delete() doesn't take a value as its argument, so it makes sense to delete all DupDort values for that key (unless `AutoDupSortKeysConversion` magic).

Also, [MDBX_ALLDUPS](https://libmdbx.dqdkfa.ru/group__c__crud.html#gga5b8137591c45143c6d9439799be77136a311b43fea13e44e2603561ec725e4f9c) is preferred to [MDBX_NODUPDATA](https://libmdbx.dqdkfa.ru/group__c__crud.html#gga5b8137591c45143c6d9439799be77136a72e67ca76a3557394d9e3aa3c387d0d6) as the flag to remove all DupSort values: https://libmdbx.dqdkfa.ru/group__c__crud.html#ga124fee3155425c8d20ca86bfd2d10831