### PR TITLE
fixing c-99

### DIFF
--- a/sais/gsa/gsaca.go
+++ b/sais/gsa/gsaca.go
@@ -2,7 +2,7 @@ package gsa
 
 /*
 #include "gsacak.h"
-#cgo CFLAGS: -DTERMINATOR=0 -DM64=1 -Dm64=1
+#cgo CFLAGS: -DTERMINATOR=0 -DM64=1 -Dm64=1 -std=c99
 */
 import "C"
 import (

--- a/sais/utils.c
+++ b/sais/utils.c
@@ -2,8 +2,8 @@
 
 int lcp_kasai(const unsigned char *T, int *SA, int *LCP, int *FTR, int *INV, int sa_size, int n)
 {
-
-    for (int i = 0, j = 0; i < sa_size; i++)
+    int j = 0;
+    for (int i = 0; i < sa_size; i++)
     {
         if ((SA[i] & 1) == 0)
             FTR[j++] = SA[i] >> 1;

--- a/sais/utils.c
+++ b/sais/utils.c
@@ -2,8 +2,7 @@
 
 int lcp_kasai(const unsigned char *T, int *SA, int *LCP, int *FTR, int *INV, int sa_size, int n)
 {
-    int j = 0;
-    for (int i = 0; i < sa_size; i++)
+    for (int i = 0, j = 0;; i < sa_size; i++)
     {
         if ((SA[i] & 1) == 0)
             FTR[j++] = SA[i] >> 1;


### PR DESCRIPTION
Solving this error reported to me: 
```
Building erigon
utils.c: In function 'lcp_kasai':
utils.c:6:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int i = 0, j = 0; i < sa_size; i++)
```