### PR TITLE
kvcache: reduce new block wait timeout 

### DIFF
--- a/kv/kvcache/cache.go
+++ b/kv/kvcache/cache.go
@@ -139,7 +139,7 @@ type CoherentConfig struct {
 
 var DefaultCoherentConfig = CoherentConfig{
 	KeepViews:     5,
-	NewBlockWait:  50 * time.Millisecond,
+	NewBlockWait:  5 * time.Millisecond,
 	KeysLimit:     1_000_000,
 	CodeKeysLimit: 10_000,
 	MetricsLabel:  "default",


### PR DESCRIPTION
- because it increasing latency when no subscription to state stream
- in future need identify - if no no subscription to state stream, then timeout must be 0