### PR TITLE
InvertedIndex don't loose last key

### DIFF
--- a/state/inverted_index.go
+++ b/state/inverted_index.go
@@ -457,11 +457,13 @@ func (it *InvertedIterator1) advance() {
 	} else if it.hasNextInDb {
 		it.nextKey = append(it.nextKey[:0], it.nextDbKey...)
 		it.advanceInDb()
+	} else {
+		it.nextKey = nil
 	}
 }
 
 func (it *InvertedIterator1) HasNext() bool {
-	return it.hasNextInFiles || it.hasNextInDb
+	return it.hasNextInFiles || it.hasNextInDb || it.nextKey != nil
 }
 
 func (it *InvertedIterator1) Next(keyBuf []byte) []byte {

--- a/state/inverted_index_test.go
+++ b/state/inverted_index_test.go
@@ -399,7 +399,8 @@ func TestChangedKeysIterator(t *testing.T) {
 		"000000000000000f",
 		"0000000000000010",
 		"0000000000000011",
-		"0000000000000012"}, keys)
+		"0000000000000012",
+		"0000000000000013"}, keys)
 	it = ic.IterateChangedKeys(995, 1000, roTx)
 	keys = keys[:0]
 	for it.HasNext() {
@@ -416,5 +417,6 @@ func TestChangedKeysIterator(t *testing.T) {
 		"0000000000000006",
 		"0000000000000009",
 		"000000000000000c",
+		"000000000000001b",
 	}, keys)
 }


### PR DESCRIPTION
now: 
if `it.hasNextInFiles == false && it.hasNextInDb == false`: we still have last key kept in `it.nextKey`. And .HasNext returns false even that last value of `it.nextKey` was never returned by `.Next()`

