### PR TITLE
Avoid redefinitions in gsacak.h

### DIFF
--- a/sais/gsa/gsacak.h
+++ b/sais/gsa/gsacak.h
@@ -120,21 +120,6 @@ int gsacak_int(int_text *s, uint_t *SA, int_t *LCP, int_da *DA, uint_t n, uint_t
 /******************************************************************************/
 
 
-#define m64 1
-
-#if m64
-	typedef int64_t  int_t;
-	typedef uint64_t uint_t;
-	#define PRIdN	 PRId64
-#else
-	typedef int32_t  int_t;
-	typedef uint32_t uint_t;
-	#define PRIdN	 PRId32
-#endif
-
-typedef uint32_t int_text;
-
-
 
 int_t SACA_K(int_t	*s, uint_t *SA,
   uint_t n, unsigned int K,


### PR DESCRIPTION
Prior to this change I got the following warnings when running `go test`:
```
In file included from sais/gsa/gsaca.go:4:
sais/gsa/gsacak.h:126:19: warning: redefinition of typedef 'int_t' is a C11 feature [-Wtypedef-redefinition]
sais/gsa/gsacak.h:49:18: note: previous definition is here
sais/gsa/gsacak.h:127:19: warning: redefinition of typedef 'uint_t' is a C11 feature [-Wtypedef-redefinition]
sais/gsa/gsacak.h:50:19: note: previous definition is here
sais/gsa/gsacak.h:135:18: warning: redefinition of typedef 'int_text' is a C11 feature [-Wtypedef-redefinition]
sais/gsa/gsacak.h:68:18: note: previous definition is here
```

It looks like `int_t`, `uint_t`, `PRId64`/`PRId32`, `int_text`, who are defined at lines 48–68, were redefined later for no good reason.