### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.49
 
       - name: Test win
         if: matrix.os == 'windows-2022'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
 #    - wastedassign # go1.18
 #    - thelper
     - gofmt
-    - deadcode
     - errcheck
     - gosimple
     - govet
@@ -18,7 +17,6 @@ linters:
     - staticcheck
 #    - structcheck # go1.18
     - unused
-    - varcheck
 #    - gocritic
     - bodyclose # go1.18
     - gosec


### PR DESCRIPTION
```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```