### PR TITLE
ParseTransaction: Validate v, r, s in signature

### DIFF
--- a/common/hexutil.go
+++ b/common/hexutil.go
@@ -1,0 +1,27 @@
+/*
+   Copyright 2022 The Erigon contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package common
+
+import "encoding/hex"
+
+func MustDecodeHex(in string) []byte {
+	payload, err := hex.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -1,0 +1,43 @@
+/*
+   Copyright 2022 The Erigon contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package crypto
+
+import (
+	"github.com/holiman/uint256"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+)
+
+var (
+	secp256k1N     = new(uint256.Int).SetBytes(common.MustDecodeHex("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"))
+	secp256k1halfN = new(uint256.Int).Rsh(secp256k1N, 1)
+)
+
+func TransactionSignatureIsValid(v byte, r, s *uint256.Int, allowPreEip2s bool, bor bool) bool {
+	if !bor { // Polygon state sync transactions have zero r & s
+		if r.IsZero() || s.IsZero() {
+			return false
+		}
+	}
+
+	// See EIP-2: Homestead Hard-fork Changes
+	if !allowPreEip2s && s.Gt(secp256k1halfN) {
+		return false
+	}
+
+	return r.Lt(secp256k1N) && s.Lt(secp256k1N) && (v == 0 || v == 1)
+}

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -27,6 +27,7 @@ var (
 	secp256k1halfN = new(uint256.Int).Rsh(secp256k1N, 1)
 )
 
+// See Appendix F "Signing Transactions" of the Yellow Paper
 func TransactionSignatureIsValid(v byte, r, s *uint256.Int, allowPreEip2s bool, bor bool) bool {
 	if !bor { // Polygon state sync transactions have zero r & s
 		if r.IsZero() || s.IsZero() {

--- a/rlp/parse_test.go
+++ b/rlp/parse_test.go
@@ -1,21 +1,14 @@
 package rlp
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
-)
 
-func decodeHex(in string) []byte {
-	payload, err := hex.DecodeString(in)
-	if err != nil {
-		panic(err)
-	}
-	return payload
-}
+	"github.com/ledgerwatch/erigon-lib/common"
+)
 
 var parseU64Tests = []struct {
 	payload   []byte
@@ -23,13 +16,13 @@ var parseU64Tests = []struct {
 	expectRes uint64
 	expectErr error
 }{
-	{payload: decodeHex("820400"), expectPos: 3, expectRes: 1024},
-	{payload: decodeHex("07"), expectPos: 1, expectRes: 7},
-	{payload: decodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("C0"), expectErr: fmt.Errorf("%w: uint64 must be a string, not isList", ErrParse)},
-	{payload: decodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
-	{payload: decodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectErr: fmt.Errorf("%w: uint64 must not be more than 8 bytes long, got 10", ErrParse)},
+	{payload: common.MustDecodeHex("820400"), expectPos: 3, expectRes: 1024},
+	{payload: common.MustDecodeHex("07"), expectPos: 1, expectRes: 7},
+	{payload: common.MustDecodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("C0"), expectErr: fmt.Errorf("%w: uint64 must be a string, not isList", ErrParse)},
+	{payload: common.MustDecodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
+	{payload: common.MustDecodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectErr: fmt.Errorf("%w: uint64 must not be more than 8 bytes long, got 10", ErrParse)},
 }
 
 var parseU32Tests = []struct {
@@ -38,13 +31,13 @@ var parseU32Tests = []struct {
 	expectRes uint32
 	expectErr error
 }{
-	{payload: decodeHex("820400"), expectPos: 3, expectRes: 1024},
-	{payload: decodeHex("07"), expectPos: 1, expectRes: 7},
-	{payload: decodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("C0"), expectErr: fmt.Errorf("%w: uint32 must be a string, not isList", ErrParse)},
-	{payload: decodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
-	{payload: decodeHex("85FF6738FF7C"), expectErr: fmt.Errorf("%w: uint32 must not be more than 4 bytes long, got 5", ErrParse)},
+	{payload: common.MustDecodeHex("820400"), expectPos: 3, expectRes: 1024},
+	{payload: common.MustDecodeHex("07"), expectPos: 1, expectRes: 7},
+	{payload: common.MustDecodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("C0"), expectErr: fmt.Errorf("%w: uint32 must be a string, not isList", ErrParse)},
+	{payload: common.MustDecodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
+	{payload: common.MustDecodeHex("85FF6738FF7C"), expectErr: fmt.Errorf("%w: uint32 must not be more than 4 bytes long, got 5", ErrParse)},
 }
 
 var parseU256Tests = []struct {
@@ -53,16 +46,16 @@ var parseU256Tests = []struct {
 	expectRes *uint256.Int
 	expectErr error
 }{
-	{payload: decodeHex("8BFFFFFFFFFFFFFFFFFF7C"), expectErr: fmt.Errorf("%w: unexpected end of payload", ErrParse)},
-	{payload: decodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectPos: 11, expectRes: new(uint256.Int).SetBytes(decodeHex("FFFFFFFFFFFFFFFFFF7C"))},
-	{payload: decodeHex("85CE05050505"), expectPos: 6, expectRes: new(uint256.Int).SetUint64(0xCE05050505)},
-	{payload: decodeHex("820400"), expectPos: 3, expectRes: new(uint256.Int).SetUint64(1024)},
-	{payload: decodeHex("07"), expectPos: 1, expectRes: new(uint256.Int).SetUint64(7)},
-	{payload: decodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
-	{payload: decodeHex("C0"), expectErr: fmt.Errorf("%w: must be a string, instead of a list", ErrParse)},
-	{payload: decodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
-	{payload: decodeHex("A101000000000000000000000000000000000000008B000000000000000000000000"), expectErr: fmt.Errorf("%w: uint256 must not be more than 32 bytes long, got 33", ErrParse)},
+	{payload: common.MustDecodeHex("8BFFFFFFFFFFFFFFFFFF7C"), expectErr: fmt.Errorf("%w: unexpected end of payload", ErrParse)},
+	{payload: common.MustDecodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectPos: 11, expectRes: new(uint256.Int).SetBytes(common.MustDecodeHex("FFFFFFFFFFFFFFFFFF7C"))},
+	{payload: common.MustDecodeHex("85CE05050505"), expectPos: 6, expectRes: new(uint256.Int).SetUint64(0xCE05050505)},
+	{payload: common.MustDecodeHex("820400"), expectPos: 3, expectRes: new(uint256.Int).SetUint64(1024)},
+	{payload: common.MustDecodeHex("07"), expectPos: 1, expectRes: new(uint256.Int).SetUint64(7)},
+	{payload: common.MustDecodeHex("8107"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("B8020004"), expectErr: fmt.Errorf("%w: non-canonical size information", ErrParse)},
+	{payload: common.MustDecodeHex("C0"), expectErr: fmt.Errorf("%w: must be a string, instead of a list", ErrParse)},
+	{payload: common.MustDecodeHex("00"), expectErr: fmt.Errorf("%w: integer encoding for RLP must not have leading zeros: 00", ErrParse)},
+	{payload: common.MustDecodeHex("A101000000000000000000000000000000000000008B000000000000000000000000"), expectErr: fmt.Errorf("%w: uint256 must not be more than 32 bytes long, got 33", ErrParse)},
 }
 
 func TestPrimitives(t *testing.T) {

--- a/types/txn.go
+++ b/types/txn.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 Erigon contributors
+   Copyright 2021 The Erigon contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -27,12 +27,14 @@ import (
 	"sort"
 
 	"github.com/holiman/uint256"
-	"github.com/ledgerwatch/erigon-lib/common/length"
-	"github.com/ledgerwatch/erigon-lib/common/u256"
-	"github.com/ledgerwatch/erigon-lib/gointerfaces/types"
-	"github.com/ledgerwatch/erigon-lib/rlp"
 	"github.com/ledgerwatch/secp256k1"
 	"golang.org/x/crypto/sha3"
+
+	"github.com/ledgerwatch/erigon-lib/common/length"
+	"github.com/ledgerwatch/erigon-lib/common/u256"
+	"github.com/ledgerwatch/erigon-lib/crypto"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/types"
+	"github.com/ledgerwatch/erigon-lib/rlp"
 )
 
 type TxParseConfig struct {
@@ -406,6 +408,10 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 
 	if !ctx.withSender {
 		return p, nil
+	}
+
+	if !crypto.TransactionSignatureIsValid(vByte, &ctx.R, &ctx.S, ctx.allowPreEip2s, ctx.withBor) {
+		return 0, fmt.Errorf("%w: invalid v, r, s: %d, %s, %s", ErrParseTxn, vByte, &ctx.R, &ctx.S)
 	}
 
 	// Computing sigHash (hash used to recover sender from the signature)

--- a/types/txn.go
+++ b/types/txn.go
@@ -52,6 +52,7 @@ type TxParseContext struct {
 	Sig              [65]byte
 	withSender       bool
 	withBor          bool
+	allowPreEip2s    bool // Allow s > secp256k1n/2; see EIP-2
 	chainIDRequired  bool
 	IsProtected      bool
 	validateRlp      func([]byte) error
@@ -79,8 +80,6 @@ func NewTxParseContext(chainID uint256.Int) *TxParseContext {
 // TxSlot contains information extracted from an Ethereum transaction, which is enough to manage it inside the transaction.
 // Also, it contains some auxillary information, like ephemeral fields, and indices within priority queues
 type TxSlot struct {
-	//txId        uint64      // Transaction id (distinct from transaction hash), used as a compact reference to a transaction accross data structures
-	//senderId    uint64      // Sender id (distinct from sender address), used as a compact referecne to to a sender accross data structures
 	Nonce          uint64      // Nonce of the transaction
 	Tip            uint256.Int // Maximum tip that transaction is giving to miner/block proposer
 	FeeCap         uint64      // Maximum fee that transaction burns and gives to the miner/block proposer
@@ -88,15 +87,12 @@ type TxSlot struct {
 	Value          uint256.Int // Value transferred by the transaction
 	IDHash         [32]byte    // Transaction hash for the purposes of using it as a transaction Id
 	SenderID       uint64      // SenderID - require external mapping to it's address
-	Traced         bool        // Whether transaction needs to be traced throughout transcation pool code and generate debug printing
-	Creation       bool        // Set to true if "To" field of the transation is not set
+	Traced         bool        // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
+	Creation       bool        // Set to true if "To" field of the transaction is not set
 	DataLen        int         // Length of transaction's data (for calculation of intrinsic gas)
 	DataNonZeroLen int
 	AlAddrCount    int // Number of addresses in the access list
 	AlStorCount    int // Number of storage keys in the access list
-	//bestIdx     int         // Index of the transaction in the best priority queue (of whatever pool it currently belongs to)
-	//worstIdx    int         // Index of the transaction in the worst priority queue (of whatever pook it currently belongs to)
-	//local       bool        // Whether transaction has been injected locally (and hence needs priority when mining or proposing a block)
 
 	IsBor bool // Wether or not the current parsed transaction is a bor transaction or not
 
@@ -121,6 +117,7 @@ var ErrRlpTooBig = errors.New("txn rlp too big")
 func (ctx *TxParseContext) ValidateRLP(f func(txnRlp []byte) error) { ctx.validateRlp = f }
 func (ctx *TxParseContext) WithSender(v bool)                       { ctx.withSender = v }
 func (ctx *TxParseContext) WithBor(v bool)                          { ctx.withBor = v }
+func (ctx *TxParseContext) WithAllowPreEip2s(v bool)                { ctx.allowPreEip2s = v }
 func (ctx *TxParseContext) ChainIDRequired() *TxParseContext {
 	ctx.chainIDRequired = true
 	return ctx
@@ -138,7 +135,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	// Compute transaction hash
 	ctx.Keccak1.Reset()
 	ctx.Keccak2.Reset()
-	// Legacy transations have list Prefix, whereas EIP-2718 transactions have string Prefix
+	// Legacy transactions have list Prefix, whereas EIP-2718 transactions have string Prefix
 	// therefore we assign the first returned value of Prefix function (list) to legacy variable
 	dataPos, dataLen, legacy, err := rlp.Prefix(payload, pos)
 	if err != nil {
@@ -236,7 +233,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	if err != nil {
 		return 0, fmt.Errorf("%w: gas: %s", ErrParseTxn, err)
 	}
-	// Next follows the destrination address (if present)
+	// Next follows the destination address (if present)
 	dataPos, dataLen, err = rlp.String(payload, p)
 	var isEmptyHash bool
 	if err != nil {

--- a/types/txn.go
+++ b/types/txn.go
@@ -35,7 +35,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-type TxParsseConfig struct {
+type TxParseConfig struct {
 	ChainID uint256.Int
 }
 
@@ -57,7 +57,7 @@ type TxParseContext struct {
 	IsProtected      bool
 	validateRlp      func([]byte) error
 
-	cfg TxParsseConfig
+	cfg TxParseConfig
 }
 
 func NewTxParseContext(chainID uint256.Int) *TxParseContext {

--- a/types/txn_packets_fuzz_test.go
+++ b/types/txn_packets_fuzz_test.go
@@ -5,14 +5,15 @@ package types
 import (
 	"testing"
 
+	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/u256"
 )
 
 func FuzzPooledTransactions66(f *testing.F) {
 	f.Add([]byte{})
-	f.Add(decodeHex("f8d7820457f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"))
-	f.Add(decodeHex("d78257f8d2f83535358202008025a00010702dfeccc57dd2d2d2d2d2d2322a463ad555a2018d2bad0203390a0a0a0a0a0a0a256d01f62b45b2e1c21c"))
-	f.Add(decodeHex("e8bfffffffffffffffffffffffff71e866666666955ef90c91f9fa08f96ebfbfbf007d765059effe33"))
+	f.Add(common.MustDecodeHex("f8d7820457f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"))
+	f.Add(common.MustDecodeHex("d78257f8d2f83535358202008025a00010702dfeccc57dd2d2d2d2d2d2322a463ad555a2018d2bad0203390a0a0a0a0a0a0a256d01f62b45b2e1c21c"))
+	f.Add(common.MustDecodeHex("e8bfffffffffffffffffffffffff71e866666666955ef90c91f9fa08f96ebfbfbf007d765059effe33"))
 	f.Fuzz(func(t *testing.T, in []byte) {
 		t.Parallel()
 		ctx := NewTxParseContext(*u256.N1)
@@ -35,7 +36,7 @@ func FuzzPooledTransactions66(f *testing.F) {
 
 func FuzzGetPooledTransactions66(f *testing.F) {
 	f.Add([]byte{})
-	f.Add(decodeHex("e68306f854e1a0595e27a835cd79729ff1eeacec3120eeb6ed1464a04ec727aaca734ead961328"))
+	f.Add(common.MustDecodeHex("e68306f854e1a0595e27a835cd79729ff1eeacec3120eeb6ed1464a04ec727aaca734ead961328"))
 	f.Fuzz(func(t *testing.T, in []byte) {
 		t.Parallel()
 		reqId, hashes, _, err := ParseGetPooledTransactions66(in, 0, nil)

--- a/types/txn_packets_test.go
+++ b/types/txn_packets_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 Erigon contributors
+   Copyright 2021 The Erigon contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,22 +17,15 @@
 package types
 
 import (
-	"encoding/hex"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
-)
 
-func decodeHex(in string) []byte {
-	payload, err := hex.DecodeString(in)
-	if err != nil {
-		panic(err)
-	}
-	return payload
-}
+	"github.com/ledgerwatch/erigon-lib/common"
+)
 
 var hashParseTests = []struct {
 	payloadStr  string
@@ -47,11 +40,11 @@ func TestParseHash(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			require := require.New(t)
 			var hashBuf [32]byte
-			payload := decodeHex(tt.payloadStr)
+			payload := common.MustDecodeHex(tt.payloadStr)
 			_, parseEnd, err := ParseHash(payload, 0, hashBuf[:0])
 			require.Equal(tt.expectedErr, err != nil)
 			require.Equal(len(payload), parseEnd)
-			require.Equal(decodeHex(tt.hashStr), hashBuf[:])
+			require.Equal(common.MustDecodeHex(tt.hashStr), hashBuf[:])
 		})
 	}
 }
@@ -73,8 +66,8 @@ func TestEncodeHash(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			require := require.New(t)
 			var encodeBuf []byte
-			encodeBuf = EncodeHashes(decodeHex(tt.hashesStr), encodeBuf)
-			require.Equal(decodeHex(tt.payloadStr), encodeBuf)
+			encodeBuf = EncodeHashes(common.MustDecodeHex(tt.hashesStr), encodeBuf)
+			require.Equal(common.MustDecodeHex(tt.payloadStr), encodeBuf)
 		})
 	}
 }
@@ -97,16 +90,16 @@ func TestEncodeGPT66(t *testing.T) {
 			require := require.New(t)
 			var encodeBuf []byte
 			var err error
-			encodeBuf, err = EncodeGetPooledTransactions66(decodeHex(tt.hashesStr), tt.requestID, encodeBuf)
+			encodeBuf, err = EncodeGetPooledTransactions66(common.MustDecodeHex(tt.hashesStr), tt.requestID, encodeBuf)
 			require.Equal(tt.expectedErr, err != nil)
-			require.Equal(decodeHex(tt.payloadStr), encodeBuf)
+			require.Equal(common.MustDecodeHex(tt.payloadStr), encodeBuf)
 			if err != nil {
 				return
 			}
 			requestID, hashes, _, err := ParseGetPooledTransactions66(encodeBuf, 0, nil)
 			require.Equal(tt.expectedErr, err != nil)
 			require.Equal(tt.requestID, requestID)
-			require.Equal(decodeHex(tt.hashesStr), hashes)
+			require.Equal(common.MustDecodeHex(tt.hashesStr), hashes)
 		})
 	}
 }
@@ -120,25 +113,25 @@ var ptp66EncodeTests = []struct {
 }{
 	{
 		txs: [][]byte{
-			decodeHex("02f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab"),
+			common.MustDecodeHex("02f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab"),
 		},
 		encoded: "f88088a4e61e8ad32f4845f875b87302f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab", requestID: 11882218248461043781, expectedErr: false, chainID: 5,
 	},
 	{
 		txs: [][]byte{
-			decodeHex("f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10"),
-			decodeHex("f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"),
+			common.MustDecodeHex("f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10"),
+			common.MustDecodeHex("f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"),
 		},
 		encoded: "f8d7820457f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb", requestID: 1111, expectedErr: false, chainID: 1,
 	},
 }
 
 func TestPooledTransactionsPacket(t *testing.T) {
-	b := decodeHex("e317e1a084a64018534279c4d3f05ea8cc7c9bfaa6f72d09c1d0a5f3be337e8b9226a680")
+	b := common.MustDecodeHex("e317e1a084a64018534279c4d3f05ea8cc7c9bfaa6f72d09c1d0a5f3be337e8b9226a680")
 	requestID, out, pos, err := ParseGetPooledTransactions66(b, 0, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(23), requestID)
-	require.Equal(t, decodeHex("84a64018534279c4d3f05ea8cc7c9bfaa6f72d09c1d0a5f3be337e8b9226a680"), out)
+	require.Equal(t, common.MustDecodeHex("84a64018534279c4d3f05ea8cc7c9bfaa6f72d09c1d0a5f3be337e8b9226a680"), out)
 	require.Equal(t, 36, pos)
 }
 
@@ -189,14 +182,14 @@ var tpEncodeTests = []struct {
 }{
 	{
 		txs: [][]byte{
-			decodeHex("02f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab"),
+			common.MustDecodeHex("02f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab"),
 		},
 		encoded: "f875b87302f870051b8477359400847735940a82520894c388750a661cc0b99784bab2c55e1f38ff91643b861319718a500080c080a028bf802cf4be66f51ab0570fa9fc06365c1b816b8a7ffe40bc05f9a0d2d12867a012c2ce1fc908e7a903b750388c8c2ae82383a476bc345b7c2826738fc321fcab", expectedErr: false, chainID: 5,
 	},
 	{
 		txs: [][]byte{
-			decodeHex("f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10"),
-			decodeHex("f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"),
+			common.MustDecodeHex("f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10"),
+			common.MustDecodeHex("f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"),
 		},
 		encoded: "f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb", expectedErr: false, chainID: 1,
 	},

--- a/types/txn_test.go
+++ b/types/txn_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 Erigon contributors
+   Copyright 2021 The Erigon contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,8 +21,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ledgerwatch/erigon-lib/common"
 )
 
 func TestParseTransactionRLP(t *testing.T) {
@@ -35,24 +38,24 @@ func TestParseTransactionRLP(t *testing.T) {
 			for i, tt := range testSet.tests {
 				tt := tt
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
-					payload := decodeHex(tt.PayloadStr)
+					payload := common.MustDecodeHex(tt.PayloadStr)
 					parseEnd, err := ctx.ParseTransaction(payload, 0, tx, txSender[:], false /* hasEnvelope */, nil)
 					require.NoError(err)
 					require.Equal(len(payload), parseEnd)
 					if tt.SignHashStr != "" {
-						signHash := decodeHex(tt.SignHashStr)
+						signHash := common.MustDecodeHex(tt.SignHashStr)
 						if !bytes.Equal(signHash, ctx.Sighash[:]) {
 							t.Errorf("signHash expected %x, got %x", signHash, ctx.Sighash)
 						}
 					}
 					if tt.IdHashStr != "" {
-						idHash := decodeHex(tt.IdHashStr)
+						idHash := common.MustDecodeHex(tt.IdHashStr)
 						if !bytes.Equal(idHash, tx.IDHash[:]) {
 							t.Errorf("IdHash expected %x, got %x", idHash, tx.IDHash)
 						}
 					}
 					if tt.SenderStr != "" {
-						expectSender := decodeHex(tt.SenderStr)
+						expectSender := common.MustDecodeHex(tt.SenderStr)
 						if !bytes.Equal(expectSender, txSender[:]) {
 							t.Errorf("expectSender expected %x, got %x", expectSender, txSender)
 						}
@@ -62,6 +65,29 @@ func TestParseTransactionRLP(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTransactionSignatureValidity(t *testing.T) {
+	chainId := new(uint256.Int).SetUint64(1)
+	ctx := NewTxParseContext(*chainId)
+	ctx.WithAllowPreEip2s(true)
+
+	tx, txSender := &TxSlot{}, [20]byte{}
+	validTxn := common.MustDecodeHex("f83f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870b801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a3664935301")
+	_, err := ctx.ParseTransaction(validTxn, 0, tx, txSender[:], false /* hasEnvelope */, nil)
+	assert.NoError(t, err)
+
+	preEip2Txn := common.MustDecodeHex("f85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870b801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1")
+	_, err = ctx.ParseTransaction(preEip2Txn, 0, tx, txSender[:], false /* hasEnvelope */, nil)
+	assert.NoError(t, err)
+
+	// Now enforce EIP-2
+	ctx.WithAllowPreEip2s(false)
+	_, err = ctx.ParseTransaction(validTxn, 0, tx, txSender[:], false /* hasEnvelope */, nil)
+	assert.NoError(t, err)
+
+	_, err = ctx.ParseTransaction(preEip2Txn, 0, tx, txSender[:], false /* hasEnvelope */, nil)
+	assert.Error(t, err)
 }
 
 func TestTxSlotsGrowth(t *testing.T) {


### PR DESCRIPTION
See Formulae (310)–(312) in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) and also Specification §2 in [EIP-2](https://eips.ethereum.org/EIPS/eip-2): Homestead Hard-fork Changes.