### PR TITLE
returning an error if offset is wrong

### DIFF
--- a/recsplit/index.go
+++ b/recsplit/index.go
@@ -90,7 +90,7 @@ func OpenIndex(indexFile string) (*Index, error) {
 	offset := 16 + 1 + int(idx.keyCount)*idx.bytesPerRec
 
 	if offset < 0 {
-		return nil, fmt.Errorf("offset is: %d which is below zero, the file is broken", offset)
+		return nil, fmt.Errorf("offset is: %d which is below zero, the file: %s is broken", offset, indexFile)
 	}
 
 	// Bucket count, bucketSize, leafSize

--- a/recsplit/index.go
+++ b/recsplit/index.go
@@ -90,7 +90,7 @@ func OpenIndex(indexFile string) (*Index, error) {
 	offset := 16 + 1 + int(idx.keyCount)*idx.bytesPerRec
 
 	if offset < 0 {
-		return nil, fmt.Errorf("offset is: %d which is below zero", offset)
+		return nil, fmt.Errorf("offset is: %d which is below zero, the file is broken", offset)
 	}
 
 	// Bucket count, bucketSize, leafSize

--- a/recsplit/index.go
+++ b/recsplit/index.go
@@ -89,6 +89,10 @@ func OpenIndex(indexFile string) (*Index, error) {
 	idx.recMask = (uint64(1) << (8 * idx.bytesPerRec)) - 1
 	offset := 16 + 1 + int(idx.keyCount)*idx.bytesPerRec
 
+	if offset < 0 {
+		return nil, fmt.Errorf("offset is: %d which is below zero", offset)
+	}
+
 	// Bucket count, bucketSize, leafSize
 	idx.bucketCount = binary.BigEndian.Uint64(idx.data[offset:])
 	offset += 8


### PR DESCRIPTION
If offset is below zero we get an error stack, but if offset is below zero it usually means that the file is broken.