### PR TITLE
Bump map size of in-memory MDBX

### DIFF
--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -121,7 +121,7 @@ func (opts MdbxOpts) Set(opt MdbxOpts) MdbxOpts {
 func (opts MdbxOpts) InMem() MdbxOpts {
 	opts.inMem = true
 	opts.flags = mdbx.UtterlyNoSync | mdbx.NoMetaSync | mdbx.LifoReclaim | mdbx.WriteMap
-	opts.mapSize = 64 * datasize.MB
+	opts.mapSize = 512 * datasize.MB
 	return opts
 }
 


### PR DESCRIPTION
In-memory MDBX is now used for block validation. Apparently for bigger blocks we were hitting its map size limit. This was reported on [Discord](https://discord.com/channels/687972960811745322/738982866670714901/1019917048681349161):

WARN] [09-15|12:13:59.260] Validation failed for header             hash=0x839fc167b39fe7eefa093f4d952912c2d40cedfc7ed171b8bed2b81a21a10225 height=15538325 err="WriteRawTransactions: txId=1742064777, baseTxId=1742064643, bucket: BlockTransaction, mdbx_cursor_put: MDBX_MAP_FULL: Environment mapsize limit reached"
