### PR TITLE
changed baseFeeCap from uint64 -> uint256

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -223,7 +223,7 @@ type metaTx struct {
 	subPool                   SubPoolMarker
 	nonceDistance             uint64 // how far their nonces are from the state's nonce for the sender
 	cumulativeBalanceDistance uint64 // how far their cumulativeRequiredBalance are from the state's balance for the sender
-	minFeeCap                 uint64
+	minFeeCap                 uint256.Int
 	minTip                    uint64
 	bestIndex                 int
 	worstIndex                int
@@ -656,7 +656,7 @@ func (p *TxPool) AddRemoteTxs(_ context.Context, newTxs types.TxSlots) {
 
 func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.CacheView) DiscardReason {
 	// Drop non-local transactions under our own minimal accepted gas price or tip
-	if !isLocal && txn.FeeCap < p.cfg.MinFeeCap {
+	if !isLocal && uint256.NewInt(p.cfg.MinFeeCap).Cmp(&txn.FeeCap) == 1 {
 		if txn.Traced {
 			log.Info(fmt.Sprintf("TX TRACING: validateTx underpriced idHash=%x local=%t, feeCap=%d, cfg.MinFeeCap=%d", txn.IDHash, isLocal, txn.FeeCap, p.cfg.MinFeeCap))
 		}
@@ -695,7 +695,7 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 	}
 	// Transactor should have enough funds to cover the costs
 	total := uint256.NewInt(txn.Gas)
-	total.Mul(total, uint256.NewInt(txn.FeeCap))
+	total.Mul(total, &txn.FeeCap)
 	total.Add(total, &txn.Value)
 	if senderBalance.Cmp(total) < 0 {
 		if txn.Traced {
@@ -1019,8 +1019,10 @@ func (p *TxPool) addLocked(mt *metaTx) DiscardReason {
 		tipThreshold := uint256.NewInt(0)
 		tipThreshold = tipThreshold.Mul(&found.Tx.Tip, uint256.NewInt(100+p.cfg.PriceBump))
 		tipThreshold.Div(tipThreshold, u256.N100)
-		feecapThreshold := found.Tx.FeeCap * (100 + p.cfg.PriceBump) / 100
-		if mt.Tx.Tip.Cmp(tipThreshold) < 0 || mt.Tx.FeeCap < feecapThreshold {
+		feecapThreshold := uint256.NewInt(0)
+		feecapThreshold.Mul(&found.Tx.FeeCap, uint256.NewInt(100+p.cfg.PriceBump))
+		feecapThreshold.Div(feecapThreshold, u256.N100)
+		if mt.Tx.Tip.Cmp(tipThreshold) < 0 || mt.Tx.FeeCap.Cmp(feecapThreshold) < 0 {
 			// Both tip and feecap need to be larger than previously to replace the transaction
 			// In case if the transation is stuck, "poke" it to rebroadcast
 			// TODO refactor to return the list of promoted hashes instead of using added inside the pool
@@ -1152,7 +1154,9 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 	protocolBaseFee, blockGasLimit uint64, pending *PendingPool, baseFee, queued *SubPool, discard func(*metaTx, DiscardReason)) {
 	noGapsNonce := senderNonce
 	cumulativeRequiredBalance := uint256.NewInt(0)
-	minFeeCap := uint64(math.MaxUint64)
+	max256 := uint256.NewInt(2)
+	max256.Exp(max256, uint256.NewInt(256))
+	minFeeCap := *max256
 	minTip := uint64(math.MaxUint64)
 	var toDel []*metaTx // can't delete items while iterate them
 	byNonce.ascend(senderID, func(mt *metaTx) bool {
@@ -1177,7 +1181,9 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 			toDel = append(toDel, mt)
 			return true
 		}
-		minFeeCap = cmp.Min(minFeeCap, mt.Tx.FeeCap)
+		if minFeeCap.Cmp(&mt.Tx.FeeCap) < 0 {
+			minFeeCap = mt.Tx.FeeCap
+		}
 		mt.minFeeCap = minFeeCap
 		if mt.Tx.Tip.IsUint64() {
 			minTip = cmp.Min(minTip, mt.Tx.Tip.Uint64())
@@ -1191,13 +1197,13 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 
 		// Sender has enough balance for: gasLimit x feeCap + transferred_value
 		needBalance := uint256.NewInt(mt.Tx.Gas)
-		needBalance.Mul(needBalance, uint256.NewInt(mt.Tx.FeeCap))
+		needBalance.Mul(needBalance, &mt.Tx.FeeCap)
 		needBalance.Add(needBalance, &mt.Tx.Value)
 		// 1. Minimum fee requirement. Set to 1 if feeCap of the transaction is no less than in-protocol
 		// parameter of minimal base fee. Set to 0 if feeCap is less than minimum base fee, which means
 		// this transaction will never be included into this particular chain.
 		mt.subPool &^= EnoughFeeCapProtocol
-		if mt.minFeeCap >= protocolBaseFee {
+		if mt.minFeeCap.Cmp(uint256.NewInt(protocolBaseFee)) >= 0 {
 			mt.subPool |= EnoughFeeCapProtocol
 		} else {
 			mt.subPool = 0 // TODO: we immediately drop all transactions if they have no first bit - then maybe we don't need this bit at all? And don't add such transactions to queue?
@@ -1261,7 +1267,7 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 // being promoted to the pending or basefee pool, for re-broadcasting
 func promote(pending *PendingPool, baseFee, queued *SubPool, pendingBaseFee uint64, discard func(*metaTx, DiscardReason)) {
 	// Demote worst transactions that do not qualify for pending sub pool anymore, to other sub pools, or discard
-	for worst := pending.Worst(); pending.Len() > 0 && (worst.subPool < BaseFeePoolBits || worst.minFeeCap < pendingBaseFee); worst = pending.Worst() {
+	for worst := pending.Worst(); pending.Len() > 0 && (worst.subPool < BaseFeePoolBits || worst.minFeeCap.Cmp(uint256.NewInt(pendingBaseFee)) < 0); worst = pending.Worst() {
 		if worst.subPool >= BaseFeePoolBits {
 			baseFee.Add(pending.PopWorst())
 		} else if worst.subPool >= QueuedPoolBits {
@@ -1272,7 +1278,7 @@ func promote(pending *PendingPool, baseFee, queued *SubPool, pendingBaseFee uint
 	}
 
 	// Promote best transactions from base fee pool to pending pool while they qualify
-	for best := baseFee.Best(); baseFee.Len() > 0 && best.subPool >= BaseFeePoolBits && best.minFeeCap >= pendingBaseFee; best = baseFee.Best() {
+	for best := baseFee.Best(); baseFee.Len() > 0 && best.subPool >= BaseFeePoolBits && best.minFeeCap.Cmp(uint256.NewInt(pendingBaseFee)) >= 0; best = baseFee.Best() {
 		pending.Add(baseFee.PopBest())
 	}
 
@@ -1287,7 +1293,7 @@ func promote(pending *PendingPool, baseFee, queued *SubPool, pendingBaseFee uint
 
 	// Promote best transactions from the queued pool to either pending or base fee pool, while they qualify
 	for best := queued.Best(); queued.Len() > 0 && best.subPool >= BaseFeePoolBits; best = queued.Best() {
-		if best.minFeeCap >= pendingBaseFee {
+		if best.minFeeCap.Cmp(uint256.NewInt(pendingBaseFee)) >= 0 {
 			pending.Add(queued.PopBest())
 		} else {
 			baseFee.Add(queued.PopBest())
@@ -2018,7 +2024,9 @@ func (s *bestSlice) Swap(i, j int) {
 	s.ms[i], s.ms[j] = s.ms[j], s.ms[i]
 	s.ms[i].bestIndex, s.ms[j].bestIndex = i, j
 }
-func (s *bestSlice) Less(i, j int) bool { return s.ms[i].better(s.ms[j], s.pendingBaseFee) }
+func (s *bestSlice) Less(i, j int) bool {
+	return s.ms[i].better(s.ms[j], *uint256.NewInt(s.pendingBaseFee))
+}
 func (s *bestSlice) UnsafeRemove(i *metaTx) {
 	s.Swap(i.bestIndex, len(s.ms)-1)
 	s.ms[len(s.ms)-1].bestIndex = -1
@@ -2172,13 +2180,13 @@ type BestQueue struct {
 	pendingBastFee uint64
 }
 
-func (mt *metaTx) better(than *metaTx, pendingBaseFee uint64) bool {
+func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 	subPool := mt.subPool
 	thanSubPool := than.subPool
-	if mt.minFeeCap >= pendingBaseFee {
+	if mt.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
 		subPool |= EnoughFeeCapBlock
 	}
-	if than.minFeeCap >= pendingBaseFee {
+	if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
 		thanSubPool |= EnoughFeeCapBlock
 	}
 	if subPool != thanSubPool {
@@ -2187,19 +2195,28 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint64) bool {
 
 	switch mt.currentSubPool {
 	case PendingSubPool:
-		var effectiveTip, thanEffectiveTip uint64
-		if pendingBaseFee <= mt.minFeeCap {
-			effectiveTip = cmp.Min(mt.minFeeCap-pendingBaseFee, mt.minTip)
+		var effectiveTip, thanEffectiveTip uint256.Int
+		if mt.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
+			if mt.minFeeCap.Cmp(uint256.NewInt(mt.minTip)) <= 0 {
+				effectiveTip = mt.minFeeCap
+			} else {
+				effectiveTip = *uint256.NewInt(mt.minTip)
+			}
 		}
-		if pendingBaseFee <= than.minFeeCap {
-			thanEffectiveTip = cmp.Min(than.minFeeCap-pendingBaseFee, than.minTip)
+		if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
+			than.minFeeCap.Sub(&than.minFeeCap, &pendingBaseFee)
+			if than.minFeeCap.Cmp(uint256.NewInt(than.minTip)) <= 0 {
+				thanEffectiveTip = than.minFeeCap
+			} else {
+				thanEffectiveTip = *uint256.NewInt(than.minTip)
+			}
 		}
-		if effectiveTip != thanEffectiveTip {
-			return effectiveTip > thanEffectiveTip
+		if effectiveTip.Cmp(&thanEffectiveTip) != 0 {
+			return effectiveTip.Cmp(&thanEffectiveTip) > 0
 		}
 	case BaseFeeSubPool:
-		if mt.minFeeCap != than.minFeeCap {
-			return mt.minFeeCap > than.minFeeCap
+		if mt.minFeeCap.Cmp(&than.minFeeCap) != 0 {
+			return mt.minFeeCap.Cmp(&than.minFeeCap) > 0
 		}
 	case QueuedSubPool:
 		if mt.nonceDistance != than.nonceDistance {
@@ -2212,13 +2229,13 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint64) bool {
 	return mt.timestamp < than.timestamp
 }
 
-func (mt *metaTx) worse(than *metaTx, pendingBaseFee uint64) bool {
+func (mt *metaTx) worse(than *metaTx, pendingBaseFee uint256.Int) bool {
 	subPool := mt.subPool
 	thanSubPool := than.subPool
-	if mt.minFeeCap >= pendingBaseFee {
+	if mt.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
 		subPool |= EnoughFeeCapBlock
 	}
-	if than.minFeeCap >= pendingBaseFee {
+	if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
 		thanSubPool |= EnoughFeeCapBlock
 	}
 	if subPool != thanSubPool {
@@ -2228,7 +2245,7 @@ func (mt *metaTx) worse(than *metaTx, pendingBaseFee uint64) bool {
 	switch mt.currentSubPool {
 	case PendingSubPool:
 		if mt.minFeeCap != than.minFeeCap {
-			return mt.minFeeCap < than.minFeeCap
+			return mt.minFeeCap.Cmp(&than.minFeeCap) < 0
 		}
 		if mt.nonceDistance != than.nonceDistance {
 			return mt.nonceDistance > than.nonceDistance
@@ -2247,8 +2264,10 @@ func (mt *metaTx) worse(than *metaTx, pendingBaseFee uint64) bool {
 	return mt.timestamp > than.timestamp
 }
 
-func (p BestQueue) Len() int           { return len(p.ms) }
-func (p BestQueue) Less(i, j int) bool { return p.ms[i].better(p.ms[j], p.pendingBastFee) }
+func (p BestQueue) Len() int { return len(p.ms) }
+func (p BestQueue) Less(i, j int) bool {
+	return p.ms[i].better(p.ms[j], *uint256.NewInt(p.pendingBastFee))
+}
 func (p BestQueue) Swap(i, j int) {
 	p.ms[i], p.ms[j] = p.ms[j], p.ms[i]
 	p.ms[i].bestIndex = i
@@ -2277,8 +2296,10 @@ type WorstQueue struct {
 	pendingBaseFee uint64
 }
 
-func (p WorstQueue) Len() int           { return len(p.ms) }
-func (p WorstQueue) Less(i, j int) bool { return p.ms[i].worse(p.ms[j], p.pendingBaseFee) }
+func (p WorstQueue) Len() int { return len(p.ms) }
+func (p WorstQueue) Less(i, j int) bool {
+	return p.ms[i].worse(p.ms[j], *uint256.NewInt(p.pendingBaseFee))
+}
 func (p WorstQueue) Swap(i, j int) {
 	p.ms[i], p.ms[j] = p.ms[j], p.ms[i]
 	p.ms[i].worstIndex = i

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2194,9 +2194,9 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 	switch mt.currentSubPool {
 	case PendingSubPool:
 		var effectiveTip, thanEffectiveTip uint256.Int
-		difference := uint256.NewInt(0)
-		difference.Sub(&than.minFeeCap, &pendingBaseFee)
 		if mt.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
+			difference := uint256.NewInt(0)
+			difference.Sub(&mt.minFeeCap, &pendingBaseFee)
 			if difference.Cmp(uint256.NewInt(mt.minTip)) <= 0 {
 				effectiveTip = *difference
 			} else {
@@ -2204,6 +2204,8 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 			}
 		}
 		if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
+			difference := uint256.NewInt(0)
+			difference.Sub(&than.minFeeCap, &pendingBaseFee)
 			if difference.Cmp(uint256.NewInt(than.minTip)) <= 0 {
 				thanEffectiveTip = *difference
 			} else {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2202,9 +2202,10 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 			}
 		}
 		if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
-			than.minFeeCap.Sub(&than.minFeeCap, &pendingBaseFee)
-			if than.minFeeCap.Cmp(uint256.NewInt(than.minTip)) <= 0 {
-				thanEffectiveTip = than.minFeeCap
+			difference := uint256.NewInt(0)
+			difference.Sub(&than.minFeeCap, &pendingBaseFee)
+			if difference.Cmp(uint256.NewInt(than.minTip)) <= 0 {
+				thanEffectiveTip = *difference
 			} else {
 				thanEffectiveTip = *uint256.NewInt(than.minTip)
 			}

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -1154,9 +1154,7 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 	protocolBaseFee, blockGasLimit uint64, pending *PendingPool, baseFee, queued *SubPool, discard func(*metaTx, DiscardReason)) {
 	noGapsNonce := senderNonce
 	cumulativeRequiredBalance := uint256.NewInt(0)
-	max256 := uint256.NewInt(2)
-	max256.Exp(max256, uint256.NewInt(256))
-	minFeeCap := *max256
+	minFeeCap := uint256.NewInt(0).SetAllOne()
 	minTip := uint64(math.MaxUint64)
 	var toDel []*metaTx // can't delete items while iterate them
 	byNonce.ascend(senderID, func(mt *metaTx) bool {
@@ -1182,9 +1180,9 @@ func onSenderStateChange(senderID uint64, senderNonce uint64, senderBalance uint
 			return true
 		}
 		if minFeeCap.Cmp(&mt.Tx.FeeCap) < 0 {
-			minFeeCap = mt.Tx.FeeCap
+			*minFeeCap = mt.Tx.FeeCap
 		}
-		mt.minFeeCap = minFeeCap
+		mt.minFeeCap = *minFeeCap
 		if mt.Tx.Tip.IsUint64() {
 			minTip = cmp.Min(minTip, mt.Tx.Tip.Uint64())
 		}

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2194,16 +2194,16 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 	switch mt.currentSubPool {
 	case PendingSubPool:
 		var effectiveTip, thanEffectiveTip uint256.Int
+		difference := uint256.NewInt(0)
+		difference.Sub(&than.minFeeCap, &pendingBaseFee)
 		if mt.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
-			if mt.minFeeCap.Cmp(uint256.NewInt(mt.minTip)) <= 0 {
-				effectiveTip = mt.minFeeCap
+			if difference.Cmp(uint256.NewInt(mt.minTip)) <= 0 {
+				effectiveTip = *difference
 			} else {
 				effectiveTip = *uint256.NewInt(mt.minTip)
 			}
 		}
 		if than.minFeeCap.Cmp(&pendingBaseFee) >= 0 {
-			difference := uint256.NewInt(0)
-			difference.Sub(&than.minFeeCap, &pendingBaseFee)
 			if difference.Cmp(uint256.NewInt(than.minTip)) <= 0 {
 				thanEffectiveTip = *difference
 			} else {

--- a/txpool/pool_fuzz_test.go
+++ b/txpool/pool_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -172,7 +173,7 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 	if !ok {
 		return nil, nil, txs, false
 	}
-	feeCap, ok := u256Slice(rawFeeCap)
+	feeCap, ok := u64Slice(rawFeeCap)
 	if !ok {
 		return nil, nil, txs, false
 	}
@@ -202,8 +203,9 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 			Nonce:  txNonce[i],
 			Value:  values[i%len(values)],
 			Tip:    *uint256.NewInt(tips[i%len(tips)]),
-			FeeCap: feeCap[i%len(feeCap)],
+			FeeCap: *uint256.NewInt(feeCap[i%len(feeCap)]),
 		}
+		fmt.Println(i)
 		txRlp := fakeRlpTx(txs.Txs[i], senders.At(i%senders.Len()))
 		_, err := parseCtx.ParseTransaction(txRlp, 0, txs.Txs[i], nil, false, nil)
 		if err != nil {

--- a/txpool/pool_fuzz_test.go
+++ b/txpool/pool_fuzz_test.go
@@ -172,7 +172,7 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 	if !ok {
 		return nil, nil, txs, false
 	}
-	feeCap, ok := u8Slice(rawFeeCap)
+	feeCap, ok := u256Slice(rawFeeCap)
 	if !ok {
 		return nil, nil, txs, false
 	}
@@ -219,7 +219,7 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 // fakeRlpTx add anything what identifying tx to `data` to make hash unique
 func fakeRlpTx(slot *types.TxSlot, data []byte) []byte {
 	dataLen := rlp.U64Len(1) + //chainID
-		rlp.U64Len(slot.Nonce) + rlp.U256Len(&slot.Tip) + rlp.U64Len(slot.FeeCap) +
+		rlp.U64Len(slot.Nonce) + rlp.U256Len(&slot.Tip) + rlp.U256Len(&slot.FeeCap) +
 		rlp.U64Len(0) + // gas
 		rlp.StringLen(0) + // dest addr
 		rlp.U256Len(&slot.Value) +
@@ -236,7 +236,7 @@ func fakeRlpTx(slot *types.TxSlot, data []byte) []byte {
 	bb := bytes.NewBuffer(buf[p:p])
 	_ = slot.Tip.EncodeRLP(bb)
 	p += rlp.U256Len(&slot.Tip)
-	p += rlp.EncodeU64(slot.FeeCap, buf[p:])
+	p += rlp.U256Len(&slot.FeeCap)
 	p += rlp.EncodeU64(0, buf[p:])           //gas
 	p += rlp.EncodeString([]byte{}, buf[p:]) //destrination addr
 	bb = bytes.NewBuffer(buf[p:p])

--- a/txpool/pool_fuzz_test.go
+++ b/txpool/pool_fuzz_test.go
@@ -172,7 +172,7 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 	if !ok {
 		return nil, nil, txs, false
 	}
-	feeCap, ok := u64Slice(rawFeeCap)
+	feeCap, ok := u8Slice(rawFeeCap)
 	if !ok {
 		return nil, nil, txs, false
 	}
@@ -236,6 +236,8 @@ func fakeRlpTx(slot *types.TxSlot, data []byte) []byte {
 	bb := bytes.NewBuffer(buf[p:p])
 	_ = slot.Tip.EncodeRLP(bb)
 	p += rlp.U256Len(&slot.Tip)
+	bb = bytes.NewBuffer(buf[p:p])
+	_ = slot.FeeCap.EncodeRLP(bb)
 	p += rlp.U256Len(&slot.FeeCap)
 	p += rlp.EncodeU64(0, buf[p:])           //gas
 	p += rlp.EncodeString([]byte{}, buf[p:]) //destrination addr

--- a/txpool/pool_fuzz_test.go
+++ b/txpool/pool_fuzz_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -205,7 +204,6 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 			Tip:    *uint256.NewInt(tips[i%len(tips)]),
 			FeeCap: *uint256.NewInt(feeCap[i%len(feeCap)]),
 		}
-		fmt.Println(i)
 		txRlp := fakeRlpTx(txs.Txs[i], senders.At(i%senders.Len()))
 		_, err := parseCtx.ParseTransaction(txRlp, 0, txs.Txs[i], nil, false, nil)
 		if err != nil {

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -133,7 +133,7 @@ func TestNonceFromAddress(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot1 := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -151,14 +151,14 @@ func TestNonceFromAddress(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot2 := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  4,
 		}
 		txSlot2.IDHash[0] = 2
 		txSlot3 := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  6,
 		}
@@ -179,7 +179,7 @@ func TestNonceFromAddress(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot1 := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 9 * common.Ether,
+			FeeCap: *uint256.NewInt(9 * common.Ether),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -197,7 +197,7 @@ func TestNonceFromAddress(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot1 := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  1,
 		}
@@ -257,7 +257,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -275,7 +275,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 3000000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -295,7 +295,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(3000000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -315,7 +315,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(330000),
-			FeeCap: 330000,
+			FeeCap: *uint256.NewInt(330000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -378,7 +378,7 @@ func TestReverseNonces(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(500_000),
-			FeeCap: 3_000_000,
+			FeeCap: *uint256.NewInt(3_000_000),
 			Gas:    100000,
 			Nonce:  3,
 		}
@@ -405,7 +405,7 @@ func TestReverseNonces(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(500_000),
-			FeeCap: 500_000,
+			FeeCap: *uint256.NewInt(500_000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -432,7 +432,7 @@ func TestReverseNonces(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(600_000),
-			FeeCap: 3_000_000,
+			FeeCap: *uint256.NewInt(3_000_000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -507,7 +507,7 @@ func TestTxPoke(t *testing.T) {
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -535,7 +535,7 @@ func TestTxPoke(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -564,7 +564,7 @@ func TestTxPoke(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(3000000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -594,7 +594,7 @@ func TestTxPoke(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(300000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(300000),
 			Gas:    100000,
 			Nonce:  2,
 		}
@@ -616,7 +616,7 @@ func TestTxPoke(t *testing.T) {
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
 			Tip:    *uint256.NewInt(3000000),
-			FeeCap: 300000,
+			FeeCap: *uint256.NewInt(3000000),
 			Gas:    100000,
 			Nonce:  2,
 		}

--- a/types/txn.go
+++ b/types/txn.go
@@ -82,7 +82,7 @@ func NewTxParseContext(chainID uint256.Int) *TxParseContext {
 type TxSlot struct {
 	Nonce          uint64      // Nonce of the transaction
 	Tip            uint256.Int // Maximum tip that transaction is giving to miner/block proposer
-	FeeCap         uint64      // Maximum fee that transaction burns and gives to the miner/block proposer
+	FeeCap         uint256.Int // Maximum fee that transaction burns and gives to the miner/block proposer
 	Gas            uint64      // Gas limit of the transaction
 	Value          uint256.Int // Value transferred by the transaction
 	IDHash         [32]byte    // Transaction hash for the purposes of using it as a transaction Id
@@ -215,10 +215,10 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	// Next follows feeCap, but only for dynamic fee transactions, for legacy transaction, it is
 	// equal to tip
 	if txType < DynamicFeeTxType {
-		slot.FeeCap = slot.Tip.Uint64()
+		slot.FeeCap = slot.Tip
 	} else {
 		// Although consensus rules specify that feeCap can be up to 256 bit long, we narrow it to 64 bit
-		p, slot.FeeCap, err = rlp.U64(payload, p)
+		p, err = rlp.U256(payload, p, &slot.FeeCap)
 		if err != nil {
 			return 0, fmt.Errorf("%w: feeCap: %s", ErrParseTxn, err)
 		}


### PR DESCRIPTION
Changing FeeCap to use uint256 instead of uint64 for gnosis chain 
Getting rid of this error: 
```
[txpool.fetch] Handling incoming message msg=POOLED_TRANSACTIONS_66 err="rlp parse transaction: feeCap: rlp parse: uint64 must not be more than 8 bytes long, got 20"
```