### PR TITLE
allow mem-mutation to create buckets

### DIFF
--- a/kv/memdb/memory_mutation.go
+++ b/kv/memdb/memory_mutation.go
@@ -274,7 +274,7 @@ func (m *MemoryMutation) CollectMetrics() {
 }
 
 func (m *MemoryMutation) CreateBucket(bucket string) error {
-	panic("Not implemented")
+	return m.memTx.CreateBucket(bucket)
 }
 
 func (m *MemoryMutation) Flush(tx kv.RwTx) error {


### PR DESCRIPTION
Some users get stuck because sometimes they get a payload and mem-mutation tries to create a Bodies bucket, but panics since its not implemented. That causes erigon to mark a good payload as bad and leaving erigon not able to sync