### PR TITLE
erigon3: step toward background snapshots build

### DIFF
--- a/state/domain.go
+++ b/state/domain.go
@@ -866,7 +866,7 @@ func (d *Domain) prune(step uint64, txFrom, txTo uint64) error {
 		return fmt.Errorf("iterate over %s vals: %w", d.filenameBase, err)
 	}
 
-	if err = d.History.prune(step, txFrom, txTo); err != nil {
+	if err = d.History.prune(txFrom, txTo); err != nil {
 		return fmt.Errorf("prune history at step %d [%d, %d): %w", step, txFrom, txTo, err)
 	}
 	return nil

--- a/state/history.go
+++ b/state/history.go
@@ -648,7 +648,7 @@ func (h *History) integrateFiles(sf HistoryFiles, txNumFrom, txNumTo uint64) {
 }
 
 // [txFrom; txTo)
-func (h *History) prune(step uint64, txFrom, txTo uint64) error {
+func (h *History) prune(txFrom, txTo uint64) error {
 	historyKeysCursor, err := h.tx.RwCursorDupSort(h.indexKeysTable)
 	if err != nil {
 		return fmt.Errorf("create %s history cursor: %w", h.filenameBase, err)

--- a/state/history_test.go
+++ b/state/history_test.go
@@ -202,7 +202,7 @@ func TestHistoryAfterPrune(t *testing.T) {
 
 	h.integrateFiles(sf, 0, 16)
 
-	err = h.prune(0, 0, 16)
+	err = h.prune(0, 16)
 	require.NoError(t, err)
 	err = tx.Commit()
 	require.NoError(t, err)
@@ -313,7 +313,7 @@ func TestHistoryHistory(t *testing.T) {
 			tx, err = db.BeginRw(context.Background())
 			require.NoError(t, err)
 			h.SetTx(tx)
-			err = h.prune(step, step*h.aggregationStep, (step+1)*h.aggregationStep)
+			err = h.prune(step*h.aggregationStep, (step+1)*h.aggregationStep)
 			require.NoError(t, err)
 			err = tx.Commit()
 			require.NoError(t, err)
@@ -346,7 +346,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64) {
 			tx, err = db.BeginRw(context.Background())
 			require.NoError(tb, err)
 			h.SetTx(tx)
-			err = h.prune(step, step*h.aggregationStep, (step+1)*h.aggregationStep)
+			err = h.prune(step*h.aggregationStep, (step+1)*h.aggregationStep)
 			require.NoError(tb, err)
 			err = tx.Commit()
 			require.NoError(tb, err)


### PR DESCRIPTION
make it more "kill -9 friendly": calc set number based on what files we have (not on what we execute now, because there execution can be way ahead of snapshots creation - if "kill -9" before files construction finished) don't expect to see all txNum values, prune [0, step+1) range instead of [step, step+1) to remove potential garbage
