### PR TITLE
feat: implement eliasfano32.Min()

### DIFF
--- a/recsplit/eliasfano32/elias_fano_fuzz_test.go
+++ b/recsplit/eliasfano32/elias_fano_fuzz_test.go
@@ -65,6 +65,9 @@ func FuzzSingleEliasFano(f *testing.F) {
 		if ef.Max() != Max(buf.Bytes()) {
 			t.Fatalf("max: got %d, expected %d", ef.Max(), Max(buf.Bytes()))
 		}
+		if ef.Min() != Min(buf.Bytes()) {
+			t.Fatalf("min: got %d, expected %d", ef.Min(), Min(buf.Bytes()))
+		}
 	})
 }
 

--- a/recsplit/eliasfano32/elias_fano_test.go
+++ b/recsplit/eliasfano32/elias_fano_test.go
@@ -55,6 +55,7 @@ func TestEliasFano(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	ef.Write(buf)
 	assert.Equal(t, ef.Max(), Max(buf.Bytes()))
+	assert.Equal(t, ef.Min(), Min(buf.Bytes()))
 }
 
 func TestIterator(t *testing.T) {


### PR DESCRIPTION
feat: implement eliasfano32.Min()
feature:
1. implement eliasfano32.Min() by calculating lower/upper bits.

refactor:
1. fix miscalculate of `superQSize` Annotation

relevant Issue in erigon: https://github.com/ledgerwatch/erigon/issues/5623 

