### PR TITLE
Fieldalign

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,6 @@ linters-settings:
   govet:
     disable:
       - deepequalerrors
-      - fieldalignment
       - shadow
       - unsafeptr
   goconst:

--- a/aggregator/history.go
+++ b/aggregator/history.go
@@ -37,8 +37,8 @@ import (
 // History is a utility class that allows reading history of state
 // from state files, history files, and bitmap files produced by an Aggregator
 type History struct {
-	diffDir         string // Directory where the state diff files are stored
 	files           [NumberOfTypes]*btree.BTreeG[*byEndBlockItem]
+	diffDir         string // Directory where the state diff files are stored
 	aggregationStep uint64
 }
 

--- a/bptree/binary_file.go
+++ b/bptree/binary_file.go
@@ -31,10 +31,10 @@ const BLOCKSIZE int64 = 4096
 
 // BinaryFile type represents an open binary file.
 type BinaryFile struct {
+	file      *os.File
 	path      string
 	blockSize int64
 	size      int64
-	file      *os.File
 	opened    bool
 }
 

--- a/bptree/node.go
+++ b/bptree/node.go
@@ -77,10 +77,10 @@ func (kv KeyValues) String() string {
 }
 
 type Node23 struct {
-	isLeaf   bool
 	children []*Node23
 	keys     []*Felt
 	values   []*Felt
+	isLeaf   bool
 	exposed  bool
 	updated  bool
 }

--- a/bptree/tree_test.go
+++ b/bptree/tree_test.go
@@ -57,8 +57,8 @@ type IsTree23Test struct {
 }
 
 type RootHashTest struct {
-	initialItems KeyValues
 	expectedHash string
+	initialItems KeyValues
 }
 
 type UpsertTest struct {
@@ -112,9 +112,9 @@ var isTree23TestTable = []IsTree23Test{
 }
 
 var rootHashTestTable = []RootHashTest{
-	{K([]Felt{}), ""},
-	{K([]Felt{1}), "532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9"},
-	{K([]Felt{1, 2}), "d3782c59c224da5b6344108ef3431ba4e01d2c30b6570137a91b8b383908c361"},
+	{"", K([]Felt{})},
+	{"532deabf88729cb43995ab5a9cd49bf9b90a079904dc0645ecda9e47ce7345a9", K([]Felt{1})},
+	{"d3782c59c224da5b6344108ef3431ba4e01d2c30b6570137a91b8b383908c361", K([]Felt{1, 2})},
 }
 
 var insertTestTable = []UpsertTest{

--- a/chain/chain_config.go
+++ b/chain/chain_config.go
@@ -26,28 +26,23 @@ import (
 // that any network, identified by its genesis block, can have its own
 // set of configuration options.
 type Config struct {
-	ChainName string
-	ChainID   *big.Int `json:"chainId"` // chainId identifies the current chain and is used for replay protection
-
-	HomesteadBlock *big.Int `json:"homesteadBlock,omitempty"` // Homestead switch block (nil = no fork, 0 = already homestead)
-
-	DAOForkBlock   *big.Int `json:"daoForkBlock,omitempty"`   // TheDAO hard-fork switch block (nil = no fork)
-	DAOForkSupport bool     `json:"daoForkSupport,omitempty"` // Whether the nodes supports or opposes the DAO hard-fork
-
+	MuirGlacierBlock *big.Int `json:"muirGlacierBlock,omitempty"` // EIP-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
+	EIP155Block      *big.Int `json:"eip155Block,omitempty"`      // EIP155 HF block
+	HomesteadBlock   *big.Int `json:"homesteadBlock,omitempty"`   // Homestead switch block (nil = no fork, 0 = already homestead)
+	DAOForkBlock     *big.Int `json:"daoForkBlock,omitempty"`     // TheDAO hard-fork switch block (nil = no fork)
+	ByzantiumBlock   *big.Int `json:"byzantiumBlock,omitempty"`   // Byzantium switch block (nil = no fork, 0 = already on byzantium)
 	// EIP150 implements the Gas price changes (https://github.com/ethereum/EIPs/issues/150)
-	EIP150Block *big.Int `json:"eip150Block,omitempty"` // EIP150 HF block (nil = no fork)
-
-	EIP155Block *big.Int `json:"eip155Block,omitempty"` // EIP155 HF block
-	EIP158Block *big.Int `json:"eip158Block,omitempty"` // EIP158 HF block
-
-	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
+	EIP150Block         *big.Int `json:"eip150Block,omitempty"`         // EIP150 HF block (nil = no fork)
+	ChainID             *big.Int `json:"chainId"`                       // chainId identifies the current chain and is used for replay protection
+	EIP158Block         *big.Int `json:"eip158Block,omitempty"`         // EIP158 HF block
+	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // EIP-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
 	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
 	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
-	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // EIP-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
-	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
-	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // EIP-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
+	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
+	ChainName           string
+	DAOForkSupport      bool `json:"daoForkSupport,omitempty"` // Whether the nodes supports or opposes the DAO hard-fork
 }
 
 // Rules wraps Config and is merely syntactic sugar or can be used for functions

--- a/commitment/hex_patricia_hashed_test.go
+++ b/commitment/hex_patricia_hashed_test.go
@@ -206,14 +206,14 @@ func Test_Sepolia(t *testing.T) {
 	ms := NewMockState(t)
 
 	type TestData struct {
-		expectedRoot string
 		balances     map[string][]byte
+		expectedRoot string
 	}
 
 	tests := []TestData{
 		{
-			"5eb6e371a698b8d68f665192350ffcecbbbf322916f4b51bd79bb6887da3f494",
-			map[string][]byte{
+			expectedRoot: "5eb6e371a698b8d68f665192350ffcecbbbf322916f4b51bd79bb6887da3f494",
+			balances: map[string][]byte{
 				"a2a6d93439144ffe4d27c9e088dcd8b783946263": {0xd3, 0xc2, 0x1b, 0xce, 0xcc, 0xed, 0xa1, 0x00, 0x00, 0x00},
 				"bc11295936aa79d594139de1b2e12629414f3bdb": {0xd3, 0xc2, 0x1b, 0xce, 0xcc, 0xed, 0xa1, 0x00, 0x00, 0x00},
 				"7cf5b79bfe291a67ab02b393e456ccc4c266f753": {0xd3, 0xc2, 0x1b, 0xce, 0xcc, 0xed, 0xa1, 0x00, 0x00, 0x00},
@@ -232,14 +232,14 @@ func Test_Sepolia(t *testing.T) {
 			},
 		},
 		{
-			"c91d4ecd59dce3067d340b3aadfc0542974b4fb4db98af39f980a91ea00db9dc",
-			map[string][]byte{
+			expectedRoot: "c91d4ecd59dce3067d340b3aadfc0542974b4fb4db98af39f980a91ea00db9dc",
+			balances: map[string][]byte{
 				"2f14582947e292a2ecd20c430b46f2d27cfe213c": {0x1B, 0xC1, 0x6D, 0x67, 0x4E, 0xC8, 0x00, 0x00},
 			},
 		},
 		{
-			"c91d4ecd59dce3067d340b3aadfc0542974b4fb4db98af39f980a91ea00db9dc",
-			map[string][]byte{},
+			expectedRoot: "c91d4ecd59dce3067d340b3aadfc0542974b4fb4db98af39f980a91ea00db9dc",
+			balances:     map[string][]byte{},
 		},
 	}
 

--- a/commitment/patricia_state_mock_test.go
+++ b/commitment/patricia_state_mock_test.go
@@ -17,9 +17,9 @@ import (
 // In memory commitment and state to use with the tests
 type MockState struct {
 	t      *testing.T
-	numBuf [binary.MaxVarintLen64]byte
 	sm     map[string][]byte     // backbone of the state
 	cm     map[string]BranchData // backbone of the commitments
+	numBuf [binary.MaxVarintLen64]byte
 }
 
 func NewMockState(t *testing.T) *MockState {

--- a/common/background/progress.go
+++ b/common/background/progress.go
@@ -24,9 +24,9 @@ func (p *Progress) percent() int {
 
 // ProgressSet - tracks multiple background job progress
 type ProgressSet struct {
-	lock sync.RWMutex
-	i    int
 	b    *btree.BTreeG[*Progress]
+	i    int
+	lock sync.RWMutex
 }
 
 func NewProgressSet() *ProgressSet {

--- a/compress/decompress.go
+++ b/compress/decompress.go
@@ -29,17 +29,17 @@ import (
 type word []byte // plain text word associated with code from dictionary
 
 type codeword struct {
-	code    uint16        // code associated with that word
-	len     byte          // Number of bits in the codes
 	pattern *word         // Pattern corresponding to entries
 	ptr     *patternTable // pointer to deeper level tables
 	next    *codeword     // points to next word in condensed table
+	code    uint16        // code associated with that word
+	len     byte          // Number of bits in the codes
 }
 
 type patternTable struct {
-	bitLen   int // Number of bits to lookup in the table
-	patterns []*codeword
 	head     *codeword
+	patterns []*codeword
+	bitLen   int // Number of bits to lookup in the table
 }
 
 func newPatternTable(bitLen int) *patternTable {
@@ -115,25 +115,25 @@ func (pt *patternTable) condensedTableSearch(code uint16) *codeword {
 }
 
 type posTable struct {
-	bitLen int // Number of bits to lookup in the table
 	pos    []uint64
 	lens   []byte
 	ptrs   []*posTable
+	bitLen int
 }
 
 // Decompressor provides access to the superstrings in a file produced by a compressor
 type Decompressor struct {
-	compressedFile string
-	f              *os.File
-	mmapHandle1    []byte                 // mmap handle for unix (this is used to close mmap)
-	mmapHandle2    *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
-	data           []byte                 // slice of correct size for the decompressor to work with
-	dict           *patternTable
-	posDict        *posTable
-	wordsStart     uint64 // Offset of whether the superstrings actually start
-	size           int64
-
-	wordsCount, emptyWordsCount uint64
+	f               *os.File
+	mmapHandle2     *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
+	dict            *patternTable
+	posDict         *posTable
+	compressedFile  string
+	mmapHandle1     []byte // mmap handle for unix (this is used to close mmap)
+	data            []byte // slice of correct size for the decompressor to work with
+	wordsStart      uint64 // Offset of whether the superstrings actually start
+	size            int64
+	wordsCount      uint64
+	emptyWordsCount uint64
 }
 
 // Tables with bitlen greater than threshold will be condensed.
@@ -384,12 +384,12 @@ func (d *Decompressor) EnableWillNeed() *Decompressor {
 // Getter represent "reader" or "interator" that can move accross the data of the decompressor
 // The full state of the getter can be captured by saving dataP, and dataBit
 type Getter struct {
-	data        []byte
-	dataP       uint64
-	dataBit     int // Value 0..7 - position of the bit
 	patternDict *patternTable
 	posDict     *posTable
 	fName       string
+	data        []byte
+	dataP       uint64
+	dataBit     int // Value 0..7 - position of the bit
 	trace       bool
 }
 

--- a/compress/parallel_compress.go
+++ b/compress/parallel_compress.go
@@ -206,8 +206,8 @@ func reduceDictWorker(trace bool, inputCh chan *CompressionWord, outCh chan *Com
 // To allow multiple words to be processed concurrently, order field is used to collect all
 // the words after processing without disrupting their order
 type CompressionWord struct {
-	order uint64
 	word  []byte
+	order uint64
 }
 
 type CompressionQueue []*CompressionWord

--- a/direct/sentry_client.go
+++ b/direct/sentry_client.go
@@ -169,8 +169,8 @@ func (c *SentryClientRemote) PeerCount(ctx context.Context, in *sentry.PeerCount
 // SentryClientDirect implements SentryClient interface by connecting the instance of the client directly with the corresponding
 // instance of SentryServer
 type SentryClientDirect struct {
-	protocol uint
 	server   sentry.SentryServer
+	protocol uint
 }
 
 func NewSentryClientDirect(protocol uint, sentryServer sentry.SentryServer) *SentryClientDirect {

--- a/etl/buffers.go
+++ b/etl/buffers.go
@@ -73,11 +73,11 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 }
 
 type sortableBuffer struct {
+	comparator  kv.CmpFunc
 	offsets     []int
 	lens        []int
 	data        []byte
 	optimalSize int
-	comparator  kv.CmpFunc
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
@@ -181,10 +181,10 @@ func NewAppendBuffer(bufferOptimalSize datasize.ByteSize) *appendSortableBuffer 
 
 type appendSortableBuffer struct {
 	entries     map[string][]byte
+	comparator  kv.CmpFunc
+	sortedBuf   []sortableBufferEntry
 	size        int
 	optimalSize int
-	sortedBuf   []sortableBufferEntry
-	comparator  kv.CmpFunc
 }
 
 func (b *appendSortableBuffer) Put(k, v []byte) {
@@ -273,10 +273,10 @@ func NewOldestEntryBuffer(bufferOptimalSize datasize.ByteSize) *oldestEntrySorta
 
 type oldestEntrySortableBuffer struct {
 	entries     map[string][]byte
+	comparator  kv.CmpFunc
+	sortedBuf   []sortableBufferEntry
 	size        int
 	optimalSize int
-	sortedBuf   []sortableBufferEntry
-	comparator  kv.CmpFunc
 }
 
 func (b *oldestEntrySortableBuffer) SetComparator(cmp kv.CmpFunc) {

--- a/etl/collector.go
+++ b/etl/collector.go
@@ -41,12 +41,12 @@ type LoadFunc func(k, v []byte, table CurrentTableReader, next LoadNextFunc) err
 type Collector struct {
 	extractNextFunc ExtractNextFunc
 	flushBuffer     func([]byte, bool) error
+	logPrefix       string
 	dataProviders   []dataProvider
-	allFlushed      bool
-	autoClean       bool
 	logLvl          log.Lvl
 	bufType         int
-	logPrefix       string
+	allFlushed      bool
+	autoClean       bool
 }
 
 // NewCollectorFromFiles creates collector from existing files (left over from previous unsuccessful loading)

--- a/etl/collector.go
+++ b/etl/collector.go
@@ -169,7 +169,7 @@ func loadFilesIntoBucket(logPrefix string, db kv.RwTx, bucket string, bufType in
 	heap.Init(h)
 	for i, provider := range providers {
 		if key, value, err := provider.Next(nil, nil); err == nil {
-			he := HeapElem{key, i, value}
+			he := HeapElem{key, value, i}
 			heap.Push(h, he)
 		} else /* we must have at least one entry per file */ {
 			eee := fmt.Errorf("%s: error reading first readers: n=%d current=%d provider=%s err=%w",

--- a/etl/etl.go
+++ b/etl/etl.go
@@ -64,17 +64,15 @@ type LoadCommitHandler func(db kv.Putter, key []byte, isDone bool) error
 type AdditionalLogArguments func(k, v []byte) (additionalLogArguments []interface{})
 
 type TransformArgs struct {
+	Quit              <-chan struct{}
+	LogDetailsExtract AdditionalLogArguments
+	LogDetailsLoad    AdditionalLogArguments
+	Comparator        kv.CmpFunc
 	// [ExtractStartKey, ExtractEndKey)
 	ExtractStartKey []byte
 	ExtractEndKey   []byte
 	BufferType      int
 	BufferSize      int
-	Quit            <-chan struct{}
-
-	LogDetailsExtract AdditionalLogArguments
-	LogDetailsLoad    AdditionalLogArguments
-
-	Comparator kv.CmpFunc
 }
 
 func Transform(

--- a/etl/heap.go
+++ b/etl/heap.go
@@ -24,8 +24,8 @@ import (
 
 type HeapElem struct {
 	Key     []byte
-	TimeIdx int
 	Value   []byte
+	TimeIdx int
 }
 
 type Heap struct {

--- a/gointerfaces/remote/mocks.go
+++ b/gointerfaces/remote/mocks.go
@@ -18,28 +18,28 @@ var _ KVClient = &KVClientMock{}
 
 // KVClientMock is a mock implementation of KVClient.
 //
-// 	func TestSomethingThatUsesKVClient(t *testing.T) {
+//	func TestSomethingThatUsesKVClient(t *testing.T) {
 //
-// 		// make and configure a mocked KVClient
-// 		mockedKVClient := &KVClientMock{
-// 			SnapshotsFunc: func(ctx context.Context, in *SnapshotsRequest, opts ...grpc.CallOption) (*SnapshotsReply, error) {
-// 				panic("mock out the Snapshots method")
-// 			},
-// 			StateChangesFunc: func(ctx context.Context, in *StateChangeRequest, opts ...grpc.CallOption) (KV_StateChangesClient, error) {
-// 				panic("mock out the StateChanges method")
-// 			},
-// 			TxFunc: func(ctx context.Context, opts ...grpc.CallOption) (KV_TxClient, error) {
-// 				panic("mock out the Tx method")
-// 			},
-// 			VersionFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.VersionReply, error) {
-// 				panic("mock out the Version method")
-// 			},
-// 		}
+//		// make and configure a mocked KVClient
+//		mockedKVClient := &KVClientMock{
+//			SnapshotsFunc: func(ctx context.Context, in *SnapshotsRequest, opts ...grpc.CallOption) (*SnapshotsReply, error) {
+//				panic("mock out the Snapshots method")
+//			},
+//			StateChangesFunc: func(ctx context.Context, in *StateChangeRequest, opts ...grpc.CallOption) (KV_StateChangesClient, error) {
+//				panic("mock out the StateChanges method")
+//			},
+//			TxFunc: func(ctx context.Context, opts ...grpc.CallOption) (KV_TxClient, error) {
+//				panic("mock out the Tx method")
+//			},
+//			VersionFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.VersionReply, error) {
+//				panic("mock out the Version method")
+//			},
+//		}
 //
-// 		// use mockedKVClient in code that requires KVClient
-// 		// and then make assertions.
+//		// use mockedKVClient in code that requires KVClient
+//		// and then make assertions.
 //
-// 	}
+//	}
 type KVClientMock struct {
 	// SnapshotsFunc mocks the Snapshots method.
 	SnapshotsFunc func(ctx context.Context, in *SnapshotsRequest, opts ...grpc.CallOption) (*SnapshotsReply, error)
@@ -122,7 +122,8 @@ func (mock *KVClientMock) Snapshots(ctx context.Context, in *SnapshotsRequest, o
 
 // SnapshotsCalls gets all the calls that were made to Snapshots.
 // Check the length with:
-//     len(mockedKVClient.SnapshotsCalls())
+//
+//	len(mockedKVClient.SnapshotsCalls())
 func (mock *KVClientMock) SnapshotsCalls() []struct {
 	Ctx  context.Context
 	In   *SnapshotsRequest
@@ -165,7 +166,8 @@ func (mock *KVClientMock) StateChanges(ctx context.Context, in *StateChangeReque
 
 // StateChangesCalls gets all the calls that were made to StateChanges.
 // Check the length with:
-//     len(mockedKVClient.StateChangesCalls())
+//
+//	len(mockedKVClient.StateChangesCalls())
 func (mock *KVClientMock) StateChangesCalls() []struct {
 	Ctx  context.Context
 	In   *StateChangeRequest
@@ -206,7 +208,8 @@ func (mock *KVClientMock) Tx(ctx context.Context, opts ...grpc.CallOption) (KV_T
 
 // TxCalls gets all the calls that were made to Tx.
 // Check the length with:
-//     len(mockedKVClient.TxCalls())
+//
+//	len(mockedKVClient.TxCalls())
 func (mock *KVClientMock) TxCalls() []struct {
 	Ctx  context.Context
 	Opts []grpc.CallOption
@@ -247,7 +250,8 @@ func (mock *KVClientMock) Version(ctx context.Context, in *emptypb.Empty, opts .
 
 // VersionCalls gets all the calls that were made to Version.
 // Check the length with:
-//     len(mockedKVClient.VersionCalls())
+//
+//	len(mockedKVClient.VersionCalls())
 func (mock *KVClientMock) VersionCalls() []struct {
 	Ctx  context.Context
 	In   *emptypb.Empty
@@ -270,37 +274,37 @@ var _ KV_StateChangesClient = &KV_StateChangesClientMock{}
 
 // KV_StateChangesClientMock is a mock implementation of KV_StateChangesClient.
 //
-// 	func TestSomethingThatUsesKV_StateChangesClient(t *testing.T) {
+//	func TestSomethingThatUsesKV_StateChangesClient(t *testing.T) {
 //
-// 		// make and configure a mocked KV_StateChangesClient
-// 		mockedKV_StateChangesClient := &KV_StateChangesClientMock{
-// 			CloseSendFunc: func() error {
-// 				panic("mock out the CloseSend method")
-// 			},
-// 			ContextFunc: func() context.Context {
-// 				panic("mock out the Context method")
-// 			},
-// 			HeaderFunc: func() (metadata.MD, error) {
-// 				panic("mock out the Header method")
-// 			},
-// 			RecvFunc: func() (*StateChangeBatch, error) {
-// 				panic("mock out the Recv method")
-// 			},
-// 			RecvMsgFunc: func(m interface{}) error {
-// 				panic("mock out the RecvMsg method")
-// 			},
-// 			SendMsgFunc: func(m interface{}) error {
-// 				panic("mock out the SendMsg method")
-// 			},
-// 			TrailerFunc: func() metadata.MD {
-// 				panic("mock out the Trailer method")
-// 			},
-// 		}
+//		// make and configure a mocked KV_StateChangesClient
+//		mockedKV_StateChangesClient := &KV_StateChangesClientMock{
+//			CloseSendFunc: func() error {
+//				panic("mock out the CloseSend method")
+//			},
+//			ContextFunc: func() context.Context {
+//				panic("mock out the Context method")
+//			},
+//			HeaderFunc: func() (metadata.MD, error) {
+//				panic("mock out the Header method")
+//			},
+//			RecvFunc: func() (*StateChangeBatch, error) {
+//				panic("mock out the Recv method")
+//			},
+//			RecvMsgFunc: func(m interface{}) error {
+//				panic("mock out the RecvMsg method")
+//			},
+//			SendMsgFunc: func(m interface{}) error {
+//				panic("mock out the SendMsg method")
+//			},
+//			TrailerFunc: func() metadata.MD {
+//				panic("mock out the Trailer method")
+//			},
+//		}
 //
-// 		// use mockedKV_StateChangesClient in code that requires KV_StateChangesClient
-// 		// and then make assertions.
+//		// use mockedKV_StateChangesClient in code that requires KV_StateChangesClient
+//		// and then make assertions.
 //
-// 	}
+//	}
 type KV_StateChangesClientMock struct {
 	// CloseSendFunc mocks the CloseSend method.
 	CloseSendFunc func() error
@@ -378,7 +382,8 @@ func (mock *KV_StateChangesClientMock) CloseSend() error {
 
 // CloseSendCalls gets all the calls that were made to CloseSend.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.CloseSendCalls())
+//
+//	len(mockedKV_StateChangesClient.CloseSendCalls())
 func (mock *KV_StateChangesClientMock) CloseSendCalls() []struct {
 } {
 	var calls []struct {
@@ -407,7 +412,8 @@ func (mock *KV_StateChangesClientMock) Context() context.Context {
 
 // ContextCalls gets all the calls that were made to Context.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.ContextCalls())
+//
+//	len(mockedKV_StateChangesClient.ContextCalls())
 func (mock *KV_StateChangesClientMock) ContextCalls() []struct {
 } {
 	var calls []struct {
@@ -437,7 +443,8 @@ func (mock *KV_StateChangesClientMock) Header() (metadata.MD, error) {
 
 // HeaderCalls gets all the calls that were made to Header.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.HeaderCalls())
+//
+//	len(mockedKV_StateChangesClient.HeaderCalls())
 func (mock *KV_StateChangesClientMock) HeaderCalls() []struct {
 } {
 	var calls []struct {
@@ -467,7 +474,8 @@ func (mock *KV_StateChangesClientMock) Recv() (*StateChangeBatch, error) {
 
 // RecvCalls gets all the calls that were made to Recv.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.RecvCalls())
+//
+//	len(mockedKV_StateChangesClient.RecvCalls())
 func (mock *KV_StateChangesClientMock) RecvCalls() []struct {
 } {
 	var calls []struct {
@@ -499,7 +507,8 @@ func (mock *KV_StateChangesClientMock) RecvMsg(m interface{}) error {
 
 // RecvMsgCalls gets all the calls that were made to RecvMsg.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.RecvMsgCalls())
+//
+//	len(mockedKV_StateChangesClient.RecvMsgCalls())
 func (mock *KV_StateChangesClientMock) RecvMsgCalls() []struct {
 	M interface{}
 } {
@@ -533,7 +542,8 @@ func (mock *KV_StateChangesClientMock) SendMsg(m interface{}) error {
 
 // SendMsgCalls gets all the calls that were made to SendMsg.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.SendMsgCalls())
+//
+//	len(mockedKV_StateChangesClient.SendMsgCalls())
 func (mock *KV_StateChangesClientMock) SendMsgCalls() []struct {
 	M interface{}
 } {
@@ -564,7 +574,8 @@ func (mock *KV_StateChangesClientMock) Trailer() metadata.MD {
 
 // TrailerCalls gets all the calls that were made to Trailer.
 // Check the length with:
-//     len(mockedKV_StateChangesClient.TrailerCalls())
+//
+//	len(mockedKV_StateChangesClient.TrailerCalls())
 func (mock *KV_StateChangesClientMock) TrailerCalls() []struct {
 } {
 	var calls []struct {

--- a/gointerfaces/sentry/mocks.go
+++ b/gointerfaces/sentry/mocks.go
@@ -17,61 +17,61 @@ var _ SentryServer = &SentryServerMock{}
 
 // SentryServerMock is a mock implementation of SentryServer.
 //
-// 	func TestSomethingThatUsesSentryServer(t *testing.T) {
+//	func TestSomethingThatUsesSentryServer(t *testing.T) {
 //
-// 		// make and configure a mocked SentryServer
-// 		mockedSentryServer := &SentryServerMock{
-// 			HandShakeFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*HandShakeReply, error) {
-// 				panic("mock out the HandShake method")
-// 			},
-// 			MessagesFunc: func(messagesRequest *MessagesRequest, sentry_MessagesServer Sentry_MessagesServer) error {
-// 				panic("mock out the Messages method")
-// 			},
-// 			NodeInfoFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*types.NodeInfoReply, error) {
-// 				panic("mock out the NodeInfo method")
-// 			},
-// 			PeerByIdFunc: func(contextMoqParam context.Context, peerByIdRequest *PeerByIdRequest) (*PeerByIdReply, error) {
-// 				panic("mock out the PeerById method")
-// 			},
-// 			PeerCountFunc: func(contextMoqParam context.Context, peerCountRequest *PeerCountRequest) (*PeerCountReply, error) {
-// 				panic("mock out the PeerCount method")
-// 			},
-// 			PeerEventsFunc: func(peerEventsRequest *PeerEventsRequest, sentry_PeerEventsServer Sentry_PeerEventsServer) error {
-// 				panic("mock out the PeerEvents method")
-// 			},
-// 			PeerMinBlockFunc: func(contextMoqParam context.Context, peerMinBlockRequest *PeerMinBlockRequest) (*emptypb.Empty, error) {
-// 				panic("mock out the PeerMinBlock method")
-// 			},
-// 			PeersFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*PeersReply, error) {
-// 				panic("mock out the Peers method")
-// 			},
-// 			PenalizePeerFunc: func(contextMoqParam context.Context, penalizePeerRequest *PenalizePeerRequest) (*emptypb.Empty, error) {
-// 				panic("mock out the PenalizePeer method")
-// 			},
-// 			SendMessageByIdFunc: func(contextMoqParam context.Context, sendMessageByIdRequest *SendMessageByIdRequest) (*SentPeers, error) {
-// 				panic("mock out the SendMessageById method")
-// 			},
-// 			SendMessageByMinBlockFunc: func(contextMoqParam context.Context, sendMessageByMinBlockRequest *SendMessageByMinBlockRequest) (*SentPeers, error) {
-// 				panic("mock out the SendMessageByMinBlock method")
-// 			},
-// 			SendMessageToAllFunc: func(contextMoqParam context.Context, outboundMessageData *OutboundMessageData) (*SentPeers, error) {
-// 				panic("mock out the SendMessageToAll method")
-// 			},
-// 			SendMessageToRandomPeersFunc: func(contextMoqParam context.Context, sendMessageToRandomPeersRequest *SendMessageToRandomPeersRequest) (*SentPeers, error) {
-// 				panic("mock out the SendMessageToRandomPeers method")
-// 			},
-// 			SetStatusFunc: func(contextMoqParam context.Context, statusData *StatusData) (*SetStatusReply, error) {
-// 				panic("mock out the SetStatus method")
-// 			},
-// 			mustEmbedUnimplementedSentryServerFunc: func()  {
-// 				panic("mock out the mustEmbedUnimplementedSentryServer method")
-// 			},
-// 		}
+//		// make and configure a mocked SentryServer
+//		mockedSentryServer := &SentryServerMock{
+//			HandShakeFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*HandShakeReply, error) {
+//				panic("mock out the HandShake method")
+//			},
+//			MessagesFunc: func(messagesRequest *MessagesRequest, sentry_MessagesServer Sentry_MessagesServer) error {
+//				panic("mock out the Messages method")
+//			},
+//			NodeInfoFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*types.NodeInfoReply, error) {
+//				panic("mock out the NodeInfo method")
+//			},
+//			PeerByIdFunc: func(contextMoqParam context.Context, peerByIdRequest *PeerByIdRequest) (*PeerByIdReply, error) {
+//				panic("mock out the PeerById method")
+//			},
+//			PeerCountFunc: func(contextMoqParam context.Context, peerCountRequest *PeerCountRequest) (*PeerCountReply, error) {
+//				panic("mock out the PeerCount method")
+//			},
+//			PeerEventsFunc: func(peerEventsRequest *PeerEventsRequest, sentry_PeerEventsServer Sentry_PeerEventsServer) error {
+//				panic("mock out the PeerEvents method")
+//			},
+//			PeerMinBlockFunc: func(contextMoqParam context.Context, peerMinBlockRequest *PeerMinBlockRequest) (*emptypb.Empty, error) {
+//				panic("mock out the PeerMinBlock method")
+//			},
+//			PeersFunc: func(contextMoqParam context.Context, empty *emptypb.Empty) (*PeersReply, error) {
+//				panic("mock out the Peers method")
+//			},
+//			PenalizePeerFunc: func(contextMoqParam context.Context, penalizePeerRequest *PenalizePeerRequest) (*emptypb.Empty, error) {
+//				panic("mock out the PenalizePeer method")
+//			},
+//			SendMessageByIdFunc: func(contextMoqParam context.Context, sendMessageByIdRequest *SendMessageByIdRequest) (*SentPeers, error) {
+//				panic("mock out the SendMessageById method")
+//			},
+//			SendMessageByMinBlockFunc: func(contextMoqParam context.Context, sendMessageByMinBlockRequest *SendMessageByMinBlockRequest) (*SentPeers, error) {
+//				panic("mock out the SendMessageByMinBlock method")
+//			},
+//			SendMessageToAllFunc: func(contextMoqParam context.Context, outboundMessageData *OutboundMessageData) (*SentPeers, error) {
+//				panic("mock out the SendMessageToAll method")
+//			},
+//			SendMessageToRandomPeersFunc: func(contextMoqParam context.Context, sendMessageToRandomPeersRequest *SendMessageToRandomPeersRequest) (*SentPeers, error) {
+//				panic("mock out the SendMessageToRandomPeers method")
+//			},
+//			SetStatusFunc: func(contextMoqParam context.Context, statusData *StatusData) (*SetStatusReply, error) {
+//				panic("mock out the SetStatus method")
+//			},
+//			mustEmbedUnimplementedSentryServerFunc: func()  {
+//				panic("mock out the mustEmbedUnimplementedSentryServer method")
+//			},
+//		}
 //
-// 		// use mockedSentryServer in code that requires SentryServer
-// 		// and then make assertions.
+//		// use mockedSentryServer in code that requires SentryServer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type SentryServerMock struct {
 	// HandShakeFunc mocks the HandShake method.
 	HandShakeFunc func(contextMoqParam context.Context, empty *emptypb.Empty) (*HandShakeReply, error)
@@ -263,7 +263,8 @@ func (mock *SentryServerMock) HandShake(contextMoqParam context.Context, empty *
 
 // HandShakeCalls gets all the calls that were made to HandShake.
 // Check the length with:
-//     len(mockedSentryServer.HandShakeCalls())
+//
+//	len(mockedSentryServer.HandShakeCalls())
 func (mock *SentryServerMock) HandShakeCalls() []struct {
 	ContextMoqParam context.Context
 	Empty           *emptypb.Empty
@@ -301,7 +302,8 @@ func (mock *SentryServerMock) Messages(messagesRequest *MessagesRequest, sentry_
 
 // MessagesCalls gets all the calls that were made to Messages.
 // Check the length with:
-//     len(mockedSentryServer.MessagesCalls())
+//
+//	len(mockedSentryServer.MessagesCalls())
 func (mock *SentryServerMock) MessagesCalls() []struct {
 	MessagesRequest       *MessagesRequest
 	Sentry_MessagesServer Sentry_MessagesServer
@@ -340,7 +342,8 @@ func (mock *SentryServerMock) NodeInfo(contextMoqParam context.Context, empty *e
 
 // NodeInfoCalls gets all the calls that were made to NodeInfo.
 // Check the length with:
-//     len(mockedSentryServer.NodeInfoCalls())
+//
+//	len(mockedSentryServer.NodeInfoCalls())
 func (mock *SentryServerMock) NodeInfoCalls() []struct {
 	ContextMoqParam context.Context
 	Empty           *emptypb.Empty
@@ -379,7 +382,8 @@ func (mock *SentryServerMock) PeerById(contextMoqParam context.Context, peerById
 
 // PeerByIdCalls gets all the calls that were made to PeerById.
 // Check the length with:
-//     len(mockedSentryServer.PeerByIdCalls())
+//
+//	len(mockedSentryServer.PeerByIdCalls())
 func (mock *SentryServerMock) PeerByIdCalls() []struct {
 	ContextMoqParam context.Context
 	PeerByIdRequest *PeerByIdRequest
@@ -418,7 +422,8 @@ func (mock *SentryServerMock) PeerCount(contextMoqParam context.Context, peerCou
 
 // PeerCountCalls gets all the calls that were made to PeerCount.
 // Check the length with:
-//     len(mockedSentryServer.PeerCountCalls())
+//
+//	len(mockedSentryServer.PeerCountCalls())
 func (mock *SentryServerMock) PeerCountCalls() []struct {
 	ContextMoqParam  context.Context
 	PeerCountRequest *PeerCountRequest
@@ -456,7 +461,8 @@ func (mock *SentryServerMock) PeerEvents(peerEventsRequest *PeerEventsRequest, s
 
 // PeerEventsCalls gets all the calls that were made to PeerEvents.
 // Check the length with:
-//     len(mockedSentryServer.PeerEventsCalls())
+//
+//	len(mockedSentryServer.PeerEventsCalls())
 func (mock *SentryServerMock) PeerEventsCalls() []struct {
 	PeerEventsRequest       *PeerEventsRequest
 	Sentry_PeerEventsServer Sentry_PeerEventsServer
@@ -495,7 +501,8 @@ func (mock *SentryServerMock) PeerMinBlock(contextMoqParam context.Context, peer
 
 // PeerMinBlockCalls gets all the calls that were made to PeerMinBlock.
 // Check the length with:
-//     len(mockedSentryServer.PeerMinBlockCalls())
+//
+//	len(mockedSentryServer.PeerMinBlockCalls())
 func (mock *SentryServerMock) PeerMinBlockCalls() []struct {
 	ContextMoqParam     context.Context
 	PeerMinBlockRequest *PeerMinBlockRequest
@@ -534,7 +541,8 @@ func (mock *SentryServerMock) Peers(contextMoqParam context.Context, empty *empt
 
 // PeersCalls gets all the calls that were made to Peers.
 // Check the length with:
-//     len(mockedSentryServer.PeersCalls())
+//
+//	len(mockedSentryServer.PeersCalls())
 func (mock *SentryServerMock) PeersCalls() []struct {
 	ContextMoqParam context.Context
 	Empty           *emptypb.Empty
@@ -573,7 +581,8 @@ func (mock *SentryServerMock) PenalizePeer(contextMoqParam context.Context, pena
 
 // PenalizePeerCalls gets all the calls that were made to PenalizePeer.
 // Check the length with:
-//     len(mockedSentryServer.PenalizePeerCalls())
+//
+//	len(mockedSentryServer.PenalizePeerCalls())
 func (mock *SentryServerMock) PenalizePeerCalls() []struct {
 	ContextMoqParam     context.Context
 	PenalizePeerRequest *PenalizePeerRequest
@@ -612,7 +621,8 @@ func (mock *SentryServerMock) SendMessageById(contextMoqParam context.Context, s
 
 // SendMessageByIdCalls gets all the calls that were made to SendMessageById.
 // Check the length with:
-//     len(mockedSentryServer.SendMessageByIdCalls())
+//
+//	len(mockedSentryServer.SendMessageByIdCalls())
 func (mock *SentryServerMock) SendMessageByIdCalls() []struct {
 	ContextMoqParam        context.Context
 	SendMessageByIdRequest *SendMessageByIdRequest
@@ -651,7 +661,8 @@ func (mock *SentryServerMock) SendMessageByMinBlock(contextMoqParam context.Cont
 
 // SendMessageByMinBlockCalls gets all the calls that were made to SendMessageByMinBlock.
 // Check the length with:
-//     len(mockedSentryServer.SendMessageByMinBlockCalls())
+//
+//	len(mockedSentryServer.SendMessageByMinBlockCalls())
 func (mock *SentryServerMock) SendMessageByMinBlockCalls() []struct {
 	ContextMoqParam              context.Context
 	SendMessageByMinBlockRequest *SendMessageByMinBlockRequest
@@ -690,7 +701,8 @@ func (mock *SentryServerMock) SendMessageToAll(contextMoqParam context.Context, 
 
 // SendMessageToAllCalls gets all the calls that were made to SendMessageToAll.
 // Check the length with:
-//     len(mockedSentryServer.SendMessageToAllCalls())
+//
+//	len(mockedSentryServer.SendMessageToAllCalls())
 func (mock *SentryServerMock) SendMessageToAllCalls() []struct {
 	ContextMoqParam     context.Context
 	OutboundMessageData *OutboundMessageData
@@ -729,7 +741,8 @@ func (mock *SentryServerMock) SendMessageToRandomPeers(contextMoqParam context.C
 
 // SendMessageToRandomPeersCalls gets all the calls that were made to SendMessageToRandomPeers.
 // Check the length with:
-//     len(mockedSentryServer.SendMessageToRandomPeersCalls())
+//
+//	len(mockedSentryServer.SendMessageToRandomPeersCalls())
 func (mock *SentryServerMock) SendMessageToRandomPeersCalls() []struct {
 	ContextMoqParam                 context.Context
 	SendMessageToRandomPeersRequest *SendMessageToRandomPeersRequest
@@ -768,7 +781,8 @@ func (mock *SentryServerMock) SetStatus(contextMoqParam context.Context, statusD
 
 // SetStatusCalls gets all the calls that were made to SetStatus.
 // Check the length with:
-//     len(mockedSentryServer.SetStatusCalls())
+//
+//	len(mockedSentryServer.SetStatusCalls())
 func (mock *SentryServerMock) SetStatusCalls() []struct {
 	ContextMoqParam context.Context
 	StatusData      *StatusData
@@ -798,7 +812,8 @@ func (mock *SentryServerMock) mustEmbedUnimplementedSentryServer() {
 
 // mustEmbedUnimplementedSentryServerCalls gets all the calls that were made to mustEmbedUnimplementedSentryServer.
 // Check the length with:
-//     len(mockedSentryServer.mustEmbedUnimplementedSentryServerCalls())
+//
+//	len(mockedSentryServer.mustEmbedUnimplementedSentryServerCalls())
 func (mock *SentryServerMock) mustEmbedUnimplementedSentryServerCalls() []struct {
 } {
 	var calls []struct {
@@ -815,58 +830,58 @@ var _ SentryClient = &SentryClientMock{}
 
 // SentryClientMock is a mock implementation of SentryClient.
 //
-// 	func TestSomethingThatUsesSentryClient(t *testing.T) {
+//	func TestSomethingThatUsesSentryClient(t *testing.T) {
 //
-// 		// make and configure a mocked SentryClient
-// 		mockedSentryClient := &SentryClientMock{
-// 			HandShakeFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HandShakeReply, error) {
-// 				panic("mock out the HandShake method")
-// 			},
-// 			MessagesFunc: func(ctx context.Context, in *MessagesRequest, opts ...grpc.CallOption) (Sentry_MessagesClient, error) {
-// 				panic("mock out the Messages method")
-// 			},
-// 			NodeInfoFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.NodeInfoReply, error) {
-// 				panic("mock out the NodeInfo method")
-// 			},
-// 			PeerByIdFunc: func(ctx context.Context, in *PeerByIdRequest, opts ...grpc.CallOption) (*PeerByIdReply, error) {
-// 				panic("mock out the PeerById method")
-// 			},
-// 			PeerCountFunc: func(ctx context.Context, in *PeerCountRequest, opts ...grpc.CallOption) (*PeerCountReply, error) {
-// 				panic("mock out the PeerCount method")
-// 			},
-// 			PeerEventsFunc: func(ctx context.Context, in *PeerEventsRequest, opts ...grpc.CallOption) (Sentry_PeerEventsClient, error) {
-// 				panic("mock out the PeerEvents method")
-// 			},
-// 			PeerMinBlockFunc: func(ctx context.Context, in *PeerMinBlockRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-// 				panic("mock out the PeerMinBlock method")
-// 			},
-// 			PeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PeersReply, error) {
-// 				panic("mock out the Peers method")
-// 			},
-// 			PenalizePeerFunc: func(ctx context.Context, in *PenalizePeerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-// 				panic("mock out the PenalizePeer method")
-// 			},
-// 			SendMessageByIdFunc: func(ctx context.Context, in *SendMessageByIdRequest, opts ...grpc.CallOption) (*SentPeers, error) {
-// 				panic("mock out the SendMessageById method")
-// 			},
-// 			SendMessageByMinBlockFunc: func(ctx context.Context, in *SendMessageByMinBlockRequest, opts ...grpc.CallOption) (*SentPeers, error) {
-// 				panic("mock out the SendMessageByMinBlock method")
-// 			},
-// 			SendMessageToAllFunc: func(ctx context.Context, in *OutboundMessageData, opts ...grpc.CallOption) (*SentPeers, error) {
-// 				panic("mock out the SendMessageToAll method")
-// 			},
-// 			SendMessageToRandomPeersFunc: func(ctx context.Context, in *SendMessageToRandomPeersRequest, opts ...grpc.CallOption) (*SentPeers, error) {
-// 				panic("mock out the SendMessageToRandomPeers method")
-// 			},
-// 			SetStatusFunc: func(ctx context.Context, in *StatusData, opts ...grpc.CallOption) (*SetStatusReply, error) {
-// 				panic("mock out the SetStatus method")
-// 			},
-// 		}
+//		// make and configure a mocked SentryClient
+//		mockedSentryClient := &SentryClientMock{
+//			HandShakeFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HandShakeReply, error) {
+//				panic("mock out the HandShake method")
+//			},
+//			MessagesFunc: func(ctx context.Context, in *MessagesRequest, opts ...grpc.CallOption) (Sentry_MessagesClient, error) {
+//				panic("mock out the Messages method")
+//			},
+//			NodeInfoFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.NodeInfoReply, error) {
+//				panic("mock out the NodeInfo method")
+//			},
+//			PeerByIdFunc: func(ctx context.Context, in *PeerByIdRequest, opts ...grpc.CallOption) (*PeerByIdReply, error) {
+//				panic("mock out the PeerById method")
+//			},
+//			PeerCountFunc: func(ctx context.Context, in *PeerCountRequest, opts ...grpc.CallOption) (*PeerCountReply, error) {
+//				panic("mock out the PeerCount method")
+//			},
+//			PeerEventsFunc: func(ctx context.Context, in *PeerEventsRequest, opts ...grpc.CallOption) (Sentry_PeerEventsClient, error) {
+//				panic("mock out the PeerEvents method")
+//			},
+//			PeerMinBlockFunc: func(ctx context.Context, in *PeerMinBlockRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+//				panic("mock out the PeerMinBlock method")
+//			},
+//			PeersFunc: func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PeersReply, error) {
+//				panic("mock out the Peers method")
+//			},
+//			PenalizePeerFunc: func(ctx context.Context, in *PenalizePeerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+//				panic("mock out the PenalizePeer method")
+//			},
+//			SendMessageByIdFunc: func(ctx context.Context, in *SendMessageByIdRequest, opts ...grpc.CallOption) (*SentPeers, error) {
+//				panic("mock out the SendMessageById method")
+//			},
+//			SendMessageByMinBlockFunc: func(ctx context.Context, in *SendMessageByMinBlockRequest, opts ...grpc.CallOption) (*SentPeers, error) {
+//				panic("mock out the SendMessageByMinBlock method")
+//			},
+//			SendMessageToAllFunc: func(ctx context.Context, in *OutboundMessageData, opts ...grpc.CallOption) (*SentPeers, error) {
+//				panic("mock out the SendMessageToAll method")
+//			},
+//			SendMessageToRandomPeersFunc: func(ctx context.Context, in *SendMessageToRandomPeersRequest, opts ...grpc.CallOption) (*SentPeers, error) {
+//				panic("mock out the SendMessageToRandomPeers method")
+//			},
+//			SetStatusFunc: func(ctx context.Context, in *StatusData, opts ...grpc.CallOption) (*SetStatusReply, error) {
+//				panic("mock out the SetStatus method")
+//			},
+//		}
 //
-// 		// use mockedSentryClient in code that requires SentryClient
-// 		// and then make assertions.
+//		// use mockedSentryClient in code that requires SentryClient
+//		// and then make assertions.
 //
-// 	}
+//	}
 type SentryClientMock struct {
 	// HandShakeFunc mocks the HandShake method.
 	HandShakeFunc func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HandShakeReply, error)
@@ -1081,7 +1096,8 @@ func (mock *SentryClientMock) HandShake(ctx context.Context, in *emptypb.Empty, 
 
 // HandShakeCalls gets all the calls that were made to HandShake.
 // Check the length with:
-//     len(mockedSentryClient.HandShakeCalls())
+//
+//	len(mockedSentryClient.HandShakeCalls())
 func (mock *SentryClientMock) HandShakeCalls() []struct {
 	Ctx  context.Context
 	In   *emptypb.Empty
@@ -1124,7 +1140,8 @@ func (mock *SentryClientMock) Messages(ctx context.Context, in *MessagesRequest,
 
 // MessagesCalls gets all the calls that were made to Messages.
 // Check the length with:
-//     len(mockedSentryClient.MessagesCalls())
+//
+//	len(mockedSentryClient.MessagesCalls())
 func (mock *SentryClientMock) MessagesCalls() []struct {
 	Ctx  context.Context
 	In   *MessagesRequest
@@ -1167,7 +1184,8 @@ func (mock *SentryClientMock) NodeInfo(ctx context.Context, in *emptypb.Empty, o
 
 // NodeInfoCalls gets all the calls that were made to NodeInfo.
 // Check the length with:
-//     len(mockedSentryClient.NodeInfoCalls())
+//
+//	len(mockedSentryClient.NodeInfoCalls())
 func (mock *SentryClientMock) NodeInfoCalls() []struct {
 	Ctx  context.Context
 	In   *emptypb.Empty
@@ -1210,7 +1228,8 @@ func (mock *SentryClientMock) PeerById(ctx context.Context, in *PeerByIdRequest,
 
 // PeerByIdCalls gets all the calls that were made to PeerById.
 // Check the length with:
-//     len(mockedSentryClient.PeerByIdCalls())
+//
+//	len(mockedSentryClient.PeerByIdCalls())
 func (mock *SentryClientMock) PeerByIdCalls() []struct {
 	Ctx  context.Context
 	In   *PeerByIdRequest
@@ -1253,7 +1272,8 @@ func (mock *SentryClientMock) PeerCount(ctx context.Context, in *PeerCountReques
 
 // PeerCountCalls gets all the calls that were made to PeerCount.
 // Check the length with:
-//     len(mockedSentryClient.PeerCountCalls())
+//
+//	len(mockedSentryClient.PeerCountCalls())
 func (mock *SentryClientMock) PeerCountCalls() []struct {
 	Ctx  context.Context
 	In   *PeerCountRequest
@@ -1296,7 +1316,8 @@ func (mock *SentryClientMock) PeerEvents(ctx context.Context, in *PeerEventsRequ
 
 // PeerEventsCalls gets all the calls that were made to PeerEvents.
 // Check the length with:
-//     len(mockedSentryClient.PeerEventsCalls())
+//
+//	len(mockedSentryClient.PeerEventsCalls())
 func (mock *SentryClientMock) PeerEventsCalls() []struct {
 	Ctx  context.Context
 	In   *PeerEventsRequest
@@ -1339,7 +1360,8 @@ func (mock *SentryClientMock) PeerMinBlock(ctx context.Context, in *PeerMinBlock
 
 // PeerMinBlockCalls gets all the calls that were made to PeerMinBlock.
 // Check the length with:
-//     len(mockedSentryClient.PeerMinBlockCalls())
+//
+//	len(mockedSentryClient.PeerMinBlockCalls())
 func (mock *SentryClientMock) PeerMinBlockCalls() []struct {
 	Ctx  context.Context
 	In   *PeerMinBlockRequest
@@ -1382,7 +1404,8 @@ func (mock *SentryClientMock) Peers(ctx context.Context, in *emptypb.Empty, opts
 
 // PeersCalls gets all the calls that were made to Peers.
 // Check the length with:
-//     len(mockedSentryClient.PeersCalls())
+//
+//	len(mockedSentryClient.PeersCalls())
 func (mock *SentryClientMock) PeersCalls() []struct {
 	Ctx  context.Context
 	In   *emptypb.Empty
@@ -1425,7 +1448,8 @@ func (mock *SentryClientMock) PenalizePeer(ctx context.Context, in *PenalizePeer
 
 // PenalizePeerCalls gets all the calls that were made to PenalizePeer.
 // Check the length with:
-//     len(mockedSentryClient.PenalizePeerCalls())
+//
+//	len(mockedSentryClient.PenalizePeerCalls())
 func (mock *SentryClientMock) PenalizePeerCalls() []struct {
 	Ctx  context.Context
 	In   *PenalizePeerRequest
@@ -1468,7 +1492,8 @@ func (mock *SentryClientMock) SendMessageById(ctx context.Context, in *SendMessa
 
 // SendMessageByIdCalls gets all the calls that were made to SendMessageById.
 // Check the length with:
-//     len(mockedSentryClient.SendMessageByIdCalls())
+//
+//	len(mockedSentryClient.SendMessageByIdCalls())
 func (mock *SentryClientMock) SendMessageByIdCalls() []struct {
 	Ctx  context.Context
 	In   *SendMessageByIdRequest
@@ -1511,7 +1536,8 @@ func (mock *SentryClientMock) SendMessageByMinBlock(ctx context.Context, in *Sen
 
 // SendMessageByMinBlockCalls gets all the calls that were made to SendMessageByMinBlock.
 // Check the length with:
-//     len(mockedSentryClient.SendMessageByMinBlockCalls())
+//
+//	len(mockedSentryClient.SendMessageByMinBlockCalls())
 func (mock *SentryClientMock) SendMessageByMinBlockCalls() []struct {
 	Ctx  context.Context
 	In   *SendMessageByMinBlockRequest
@@ -1554,7 +1580,8 @@ func (mock *SentryClientMock) SendMessageToAll(ctx context.Context, in *Outbound
 
 // SendMessageToAllCalls gets all the calls that were made to SendMessageToAll.
 // Check the length with:
-//     len(mockedSentryClient.SendMessageToAllCalls())
+//
+//	len(mockedSentryClient.SendMessageToAllCalls())
 func (mock *SentryClientMock) SendMessageToAllCalls() []struct {
 	Ctx  context.Context
 	In   *OutboundMessageData
@@ -1597,7 +1624,8 @@ func (mock *SentryClientMock) SendMessageToRandomPeers(ctx context.Context, in *
 
 // SendMessageToRandomPeersCalls gets all the calls that were made to SendMessageToRandomPeers.
 // Check the length with:
-//     len(mockedSentryClient.SendMessageToRandomPeersCalls())
+//
+//	len(mockedSentryClient.SendMessageToRandomPeersCalls())
 func (mock *SentryClientMock) SendMessageToRandomPeersCalls() []struct {
 	Ctx  context.Context
 	In   *SendMessageToRandomPeersRequest
@@ -1640,7 +1668,8 @@ func (mock *SentryClientMock) SetStatus(ctx context.Context, in *StatusData, opt
 
 // SetStatusCalls gets all the calls that were made to SetStatus.
 // Check the length with:
-//     len(mockedSentryClient.SetStatusCalls())
+//
+//	len(mockedSentryClient.SetStatusCalls())
 func (mock *SentryClientMock) SetStatusCalls() []struct {
 	Ctx  context.Context
 	In   *StatusData

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -351,12 +351,12 @@ func (opts MdbxOpts) MustOpen() kv.RwDB {
 }
 
 type MdbxKV struct {
-	opts         MdbxOpts
 	log          log.Logger
 	env          *mdbx.Env
 	wg           *sync.WaitGroup
 	buckets      kv.TableCfg
 	roTxsLimiter *semaphore.Weighted // does limit amount of concurrent Ro transactions - in most casess runtime.NumCPU() is good value for this channel capacity - this channel can be shared with other components (like Decompressor)
+	opts         MdbxOpts
 	txSize       uint64
 	closed       atomic.Bool
 }

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -48,23 +48,21 @@ func WithChaindataTables(defaultBuckets kv.TableCfg) kv.TableCfg {
 }
 
 type MdbxOpts struct {
-	bucketsCfg TableCfgFunc
-	path       string
-	inMem      bool
-	label      kv.Label // marker to distinct db instances - one process may open many databases. for example to collect metrics of only 1 database
-	verbosity  kv.DBVerbosityLvl
-	mapSize    datasize.ByteSize
-	growthStep datasize.ByteSize
-	flags      uint
-	log        log.Logger
-	syncPeriod time.Duration
-	pageSize   uint64
-
 	// must be in the range from 12.5% (almost empty) to 50% (half empty)
 	// which corresponds to the range from 8192 and to 32768 in units respectively
+	log            log.Logger
+	roTxsLimiter   *semaphore.Weighted
+	bucketsCfg     TableCfgFunc
+	path           string
+	syncPeriod     time.Duration
+	mapSize        datasize.ByteSize
+	growthStep     datasize.ByteSize
+	flags          uint
+	pageSize       uint64
 	mergeThreshold uint64
-
-	roTxsLimiter *semaphore.Weighted
+	verbosity      kv.DBVerbosityLvl
+	label          kv.Label // marker to distinct db instances - one process may open many databases. for example to collect metrics of only 1 database
+	inMem          bool
 }
 
 func NewMDBX(log log.Logger) MdbxOpts {
@@ -353,13 +351,13 @@ func (opts MdbxOpts) MustOpen() kv.RwDB {
 }
 
 type MdbxKV struct {
-	env          *mdbx.Env
+	opts         MdbxOpts
 	log          log.Logger
+	env          *mdbx.Env
 	wg           *sync.WaitGroup
 	buckets      kv.TableCfg
-	opts         MdbxOpts
-	txSize       uint64
 	roTxsLimiter *semaphore.Weighted // does limit amount of concurrent Ro transactions - in most casess runtime.NumCPU() is good value for this channel capacity - this channel can be shared with other components (like Decompressor)
+	txSize       uint64
 	closed       atomic.Bool
 }
 

--- a/kv/memdb/memory_mutation_cursor.go
+++ b/kv/memdb/memory_mutation_cursor.go
@@ -37,17 +37,16 @@ type cursorEntry struct {
 
 // cursor
 type memoryMutationCursor struct {
+	// entry history
 	cursor    kv.CursorDupSort
 	memCursor kv.RwCursorDupSort
-
-	isPrevFromDb bool
-	// entry history
+	// we keep the mining mutation so that we can insert new elements in db
+	mutation        *MemoryMutation
+	table           string
 	currentPair     cursorEntry
 	currentDbEntry  cursorEntry
 	currentMemEntry cursorEntry
-	// we keep the mining mutation so that we can insert new elements in db
-	mutation *MemoryMutation
-	table    string
+	isPrevFromDb    bool
 }
 
 func (m *memoryMutationCursor) isTableCleared() bool {

--- a/kv/remotedb/kv_remote.go
+++ b/kv/remotedb/kv_remote.go
@@ -20,11 +20,11 @@ import (
 
 // generate the messages and services
 type remoteOpts struct {
+	remoteKV    remote.KVClient
+	log         log.Logger
 	bucketsCfg  mdbx.TableCfgFunc
 	DialAddress string
 	version     gointerfaces.Version
-	remoteKV    remote.KVClient
-	log         log.Logger
 }
 
 type RemoteKV struct {
@@ -40,10 +40,10 @@ type remoteTx struct {
 	ctx                context.Context
 	streamCancelFn     context.CancelFunc
 	db                 *RemoteKV
-	cursors            []*remoteCursor
 	statelessCursors   map[string]kv.Cursor
-	streamingRequested bool
+	cursors            []*remoteCursor
 	id                 uint64
+	streamingRequested bool
 }
 
 type remoteCursor struct {

--- a/kv/remotedb/kv_remote.go
+++ b/kv/remotedb/kv_remote.go
@@ -31,8 +31,8 @@ type RemoteKV struct {
 	remoteKV     remote.KVClient
 	log          log.Logger
 	buckets      kv.TableCfg
-	opts         remoteOpts
 	roTxsLimiter *semaphore.Weighted
+	opts         remoteOpts
 }
 
 type remoteTx struct {

--- a/kv/remotedbserver/server.go
+++ b/kv/remotedbserver/server.go
@@ -312,9 +312,9 @@ func (s *KvServer) Snapshots(ctx context.Context, _ *remote.SnapshotsRequest) (*
 }
 
 type StateChangePubSub struct {
-	mu    sync.RWMutex
-	id    uint
 	chans map[uint]chan *remote.StateChangeBatch
+	id    uint
+	mu    sync.RWMutex
 }
 
 func newStateChangeStreams() *StateChangePubSub {

--- a/patricia/patricia.go
+++ b/patricia/patricia.go
@@ -27,12 +27,11 @@ import (
 
 // Implementation of paticia tree for efficient search of substrings from a dictionary in a given string
 type node struct {
-	p0 uint32
-	p1 uint32
-	//size   uint64
+	val interface{} // value associated with the key
 	n0  *node
 	n1  *node
-	val interface{} // value associated with the key
+	p0  uint32
+	p1  uint32
 }
 
 func tostr(x uint32) string {
@@ -345,9 +344,9 @@ func (pt PatriciaTree) Get(key []byte) (interface{}, bool) {
 }
 
 type Match struct {
+	Val   interface{}
 	Start int
 	End   int
-	Val   interface{}
 }
 
 type Matches []Match
@@ -365,9 +364,9 @@ func (m *Matches) Swap(i, j int) {
 }
 
 type MatchFinder struct {
+	pt      *PatriciaTree
 	s       state
 	matches []Match
-	pt      *PatriciaTree
 }
 
 func NewMatchFinder(pt *PatriciaTree) *MatchFinder {
@@ -375,15 +374,17 @@ func NewMatchFinder(pt *PatriciaTree) *MatchFinder {
 }
 
 type MatchFinder2 struct {
-	nodeStack    []*node
-	matchStack   []Match
-	top          *node // Top of nodeStack
-	headLen      int
-	tailLen      int
-	side         int // 0, 1, or 2 (if side is not determined yet)
-	matches      Matches
-	pt           *PatriciaTree
-	sa, lcp, inv []int32
+	top        *node // Top of nodeStack
+	pt         *PatriciaTree
+	nodeStack  []*node
+	matchStack []Match
+	matches    Matches
+	sa         []int32
+	lcp        []int32
+	inv        []int32
+	headLen    int
+	tailLen    int
+	side       int // 0, 1, or 2 (if side is not determined yet)
 }
 
 func NewMatchFinder2(pt *PatriciaTree) *MatchFinder2 {

--- a/recsplit/golomb_rice.go
+++ b/recsplit/golomb_rice.go
@@ -30,8 +30,8 @@ var bijMemo []uint32 = []uint32{0, 0, 0, 1, 3, 4, 5, 7, 8, 10, 11, 12, 14, 15, 1
 
 // GolombRice can build up the golomb-rice encoding of the sequeuce of numbers, as well as read the numbers back from it.
 type GolombRice struct {
-	bitCount int      // Speficic to the builder - number of bits added to the encoding so far
 	data     []uint64 // Present in the builder and in the reader
+	bitCount int      // Speficic to the builder - number of bits added to the encoding so far
 }
 
 // appendUnaryAll adds the unary encoding of specified sequence of numbers to the end of the

--- a/recsplit/index.go
+++ b/recsplit/index.go
@@ -33,28 +33,28 @@ import (
 
 // Index implements index lookup from the file created by the RecSplit
 type Index struct {
-	indexFile          string
-	f                  *os.File
-	mmapHandle1        []byte                 // mmap handle for unix (this is used to close mmap)
-	mmapHandle2        *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
-	data               []byte                 // slice of correct size for the index to work with
-	keyCount           uint64
-	bytesPerRec        int
-	recMask            uint64
-	grData             []uint64
-	ef                 eliasfano16.DoubleEliasFano
-	enums              bool
 	offsetEf           *eliasfano32.EliasFano
-	baseDataID         uint64
-	bucketCount        uint64 // Number of buckets
-	bucketSize         int
-	leafSize           uint16 // Leaf size for recursive split algorithms
-	primaryAggrBound   uint16 // The lower bound for primary key aggregation (computed from leafSize)
-	secondaryAggrBound uint16 // The lower bound for secondary key aggregation (computed from leadSize)
-	salt               uint32
+	f                  *os.File
+	mmapHandle2        *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
+	indexFile          string
+	grData             []uint64
+	data               []byte // slice of correct size for the index to work with
 	startSeed          []uint64
 	golombRice         []uint32
+	mmapHandle1        []byte // mmap handle for unix (this is used to close mmap)
+	ef                 eliasfano16.DoubleEliasFano
+	bucketSize         int
 	size               int64
+	baseDataID         uint64
+	bucketCount        uint64 // Number of buckets
+	keyCount           uint64
+	recMask            uint64
+	bytesPerRec        int
+	salt               uint32
+	leafSize           uint16 // Leaf size for recursive split algorithms
+	secondaryAggrBound uint16 // The lower bound for secondary key aggregation (computed from leadSize)
+	primaryAggrBound   uint16 // The lower bound for primary key aggregation (computed from leafSize)
+	enums              bool
 }
 
 func MustOpen(indexFile string) *Index {

--- a/recsplit/index_reader.go
+++ b/recsplit/index_reader.go
@@ -24,9 +24,9 @@ import (
 
 // IndexReader encapsulates Hash128 to allow concurrent access to Index
 type IndexReader struct {
-	mu     sync.RWMutex
 	hasher murmur3.Hash128
 	index  *Index
+	mu     sync.RWMutex
 }
 
 // NewIndexReader creates new IndexReader

--- a/recsplit/recsplit.go
+++ b/recsplit/recsplit.go
@@ -62,63 +62,63 @@ func remix(z uint64) uint64 {
 // Recsplit: Minimal perfect hashing via recursive splitting. In 2020 Proceedings of the Symposium on Algorithm Engineering and Experiments (ALENEX),
 // pages 175−185. SIAM, 2020.
 type RecSplit struct {
-	bucketSize        int
-	keyExpectedCount  uint64          // Number of keys in the hash table
-	keysAdded         uint64          // Number of keys actually added to the recSplit (to check the match with keyExpectedCount)
-	baseDataID        uint64          // Minimal app-specific ID of entries of this index - helps app understand what data stored in given shard - persistent field
-	bucketCount       uint64          // Number of buckets
 	hasher            murmur3.Hash128 // Salted hash function to use for splitting into initial buckets and mapping to 64-bit fingerprints
-	etlBufLimit       datasize.ByteSize
-	lvl               log.Lvl
-	bucketCollector   *etl.Collector // Collector that sorts by buckets
-	enums             bool           // Whether to build two level index with perfect hash table pointing to enumeration and enumeration pointing to offsets
-	offsetCollector   *etl.Collector // Collector that sorts by offsets
-	built             bool           // Flag indicating that the hash function has been built and no more keys can be added
-	currentBucketIdx  uint64         // Current bucket being accumulated
-	currentBucket     []uint64       // 64-bit fingerprints of keys in the current bucket accumulated before the recsplit is performed for that bucket
-	currentBucketOffs []uint64       // Index offsets for the current bucket
-	maxOffset         uint64         // Maximum value of index offset to later decide how many bytes to use for the encoding
-	gr                GolombRice     // Helper object to encode the tree of hash function salts using Golomb-Rice code.
+	offsetCollector   *etl.Collector  // Collector that sorts by offsets
+	indexW            *bufio.Writer
+	indexF            *os.File
+	offsetEf          *eliasfano32.EliasFano // Elias Fano instance for encoding the offsets
+	bucketCollector   *etl.Collector         // Collector that sorts by buckets
+	indexFileName     string
+	indexFile         string
+	tmpDir            string
+	gr                GolombRice // Helper object to encode the tree of hash function salts using Golomb-Rice code.
+	bucketPosAcc      []uint64   // Accumulator for position of every bucket in the encoding of the hash function
+	startSeed         []uint64
+	count             []uint16
+	currentBucket     []uint64 // 64-bit fingerprints of keys in the current bucket accumulated before the recsplit is performed for that bucket
+	currentBucketOffs []uint64 // Index offsets for the current bucket
+	offsetBuffer      []uint64
+	buffer            []uint64
+	golombRice        []uint32
+	bucketSizeAcc     []uint64 // Bucket size accumulator
 	// Helper object to encode the sequence of cumulative number of keys in the buckets
 	// and the sequence of of cumulative bit offsets of buckets in the Golomb-Rice code.
 	ef                 eliasfano16.DoubleEliasFano
-	offsetEf           *eliasfano32.EliasFano // Elias Fano instance for encoding the offsets
-	bucketSizeAcc      []uint64               // Bucket size accumulator
-	bucketPosAcc       []uint64               // Accumulator for position of every bucket in the encoding of the hash function
-	leafSize           uint16                 // Leaf size for recursive split algorithm
-	primaryAggrBound   uint16                 // The lower bound for primary key aggregation (computed from leafSize)
-	secondaryAggrBound uint16                 // The lower bound for secondary key aggregation (computed from leadSize)
-	startSeed          []uint64
-	golombRice         []uint32
-	buffer             []uint64
-	offsetBuffer       []uint64
-	count              []uint16
-	salt               uint32 // Murmur3 hash used for converting keys to 64-bit values and assigning to buckets
-	collision          bool
-	tmpDir             string
-	indexFile          string
-	indexFileName      string
-	indexF             *os.File
-	indexW             *bufio.Writer
+	lvl                log.Lvl
 	bytesPerRec        int
-	numBuf             [8]byte
-	bucketKeyBuf       [16]byte
-	trace              bool
-	prevOffset         uint64 // Previously added offset (for calculating minDelta for Elias Fano encoding of "enum -> offset" index)
 	minDelta           uint64 // minDelta for Elias Fano encoding of "enum -> offset" index
+	prevOffset         uint64 // Previously added offset (for calculating minDelta for Elias Fano encoding of "enum -> offset" index)
+	bucketSize         int
+	keyExpectedCount   uint64 // Number of keys in the hash table
+	keysAdded          uint64 // Number of keys actually added to the recSplit (to check the match with keyExpectedCount)
+	maxOffset          uint64 // Maximum value of index offset to later decide how many bytes to use for the encoding
+	currentBucketIdx   uint64 // Current bucket being accumulated
+	baseDataID         uint64 // Minimal app-specific ID of entries of this index - helps app understand what data stored in given shard - persistent field
+	bucketCount        uint64 // Number of buckets
+	etlBufLimit        datasize.ByteSize
+	salt               uint32 // Murmur3 hash used for converting keys to 64-bit values and assigning to buckets
+	leafSize           uint16 // Leaf size for recursive split algorithm
+	secondaryAggrBound uint16 // The lower bound for secondary key aggregation (computed from leadSize)
+	primaryAggrBound   uint16 // The lower bound for primary key aggregation (computed from leafSize)
+	bucketKeyBuf       [16]byte
+	numBuf             [8]byte
+	collision          bool
+	enums              bool // Whether to build two level index with perfect hash table pointing to enumeration and enumeration pointing to offsets
+	built              bool // Flag indicating that the hash function has been built and no more keys can be added
+	trace              bool
 }
 
 type RecSplitArgs struct {
-	KeyCount    int
-	BucketSize  int
-	Salt        uint32 // Hash seed (salt) for the hash function used for allocating the initial buckets - need to be generated randomly
-	LeafSize    uint16
 	IndexFile   string // File name where the index and the minimal perfect hash function will be written to
 	TmpDir      string
 	StartSeed   []uint64 // For each level of recursive split, the hash seed (salt) used for that level - need to be generated randomly and be large enough to accomodate all the levels
-	Enums       bool     // Whether two level index needs to be built, where perfect hash map points to an enumeration, and enumeration points to offsets
+	KeyCount    int
+	BucketSize  int
 	BaseDataID  uint64
 	EtlBufLimit datasize.ByteSize
+	Salt        uint32 // Hash seed (salt) for the hash function used for allocating the initial buckets - need to be generated randomly
+	LeafSize    uint16
+	Enums       bool // Whether two level index needs to be built, where perfect hash map points to an enumeration, and enumeration points to offsets
 }
 
 // NewRecSplit creates a new RecSplit instance with given number of keys and given bucket size

--- a/rlp/parse_test.go
+++ b/rlp/parse_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 var parseU64Tests = []struct {
+	expectErr error
 	payload   []byte
 	expectPos int
 	expectRes uint64
-	expectErr error
 }{
 	{payload: common.MustDecodeHex("820400"), expectPos: 3, expectRes: 1024},
 	{payload: common.MustDecodeHex("07"), expectPos: 1, expectRes: 7},
@@ -26,10 +26,10 @@ var parseU64Tests = []struct {
 }
 
 var parseU32Tests = []struct {
+	expectErr error
 	payload   []byte
 	expectPos int
 	expectRes uint32
-	expectErr error
 }{
 	{payload: common.MustDecodeHex("820400"), expectPos: 3, expectRes: 1024},
 	{payload: common.MustDecodeHex("07"), expectPos: 1, expectRes: 7},
@@ -41,10 +41,10 @@ var parseU32Tests = []struct {
 }
 
 var parseU256Tests = []struct {
+	expectErr error
+	expectRes *uint256.Int
 	payload   []byte
 	expectPos int
-	expectRes *uint256.Int
-	expectErr error
 }{
 	{payload: common.MustDecodeHex("8BFFFFFFFFFFFFFFFFFF7C"), expectErr: fmt.Errorf("%w: unexpected end of payload", ErrParse)},
 	{payload: common.MustDecodeHex("8AFFFFFFFFFFFFFFFFFF7C"), expectPos: 11, expectRes: new(uint256.Int).SetBytes(common.MustDecodeHex("FFFFFFFFFFFFFFFFFF7C"))},

--- a/state/aggregator.go
+++ b/state/aggregator.go
@@ -198,14 +198,14 @@ func (a *Aggregator) SetCommitmentMode(mode CommitmentMode) {
 }
 
 type AggCollation struct {
-	accounts   Collation
-	storage    Collation
-	code       Collation
-	commitment Collation
 	logAddrs   map[string]*roaring64.Bitmap
 	logTopics  map[string]*roaring64.Bitmap
 	tracesFrom map[string]*roaring64.Bitmap
 	tracesTo   map[string]*roaring64.Bitmap
+	accounts   Collation
+	storage    Collation
+	code       Collation
+	commitment Collation
 }
 
 func (c AggCollation) Close() {

--- a/state/aggregator.go
+++ b/state/aggregator.go
@@ -42,26 +42,25 @@ import (
 // Reconstruction of the aggregator in another package, `aggregator`
 
 type Aggregator struct {
-	aggregationStep uint64
-	accounts        *Domain
-	storage         *Domain
-	code            *Domain
+	keccak          hash.Hash
+	rwTx            kv.RwTx
+	logAddrs        *InvertedIndex
+	tracesTo        *InvertedIndex
 	commitment      *Domain
 	commTree        *btree.BTreeG[*CommitmentItem]
-	keccak          hash.Hash
+	storage         *Domain
 	patriciaTrie    *commitment.HexPatriciaHashed
-	logAddrs        *InvertedIndex
+	accounts        *Domain
 	logTopics       *InvertedIndex
 	tracesFrom      *InvertedIndex
-	tracesTo        *InvertedIndex
-	txNum           uint64
+	code            *Domain
+	commitFn        func(txNum uint64) error
+	tmpdir          string
+	stats           FilesStats
 	blockNum        uint64
-
-	commitmentMode CommitmentMode
-	commitFn       func(txNum uint64) error
-	rwTx           kv.RwTx
-	stats          FilesStats
-	tmpdir         string
+	commitmentMode  CommitmentMode
+	txNum           uint64
+	aggregationStep uint64
 }
 
 func NewAggregator(
@@ -420,18 +419,22 @@ func (a *Aggregator) EndTxNumMinimax() uint64 {
 }
 
 type Ranges struct {
-	accounts                                 DomainRanges
-	storage                                  DomainRanges
-	code                                     DomainRanges
-	commitment                               DomainRanges
-	logAddrsStartTxNum, logAddrsEndTxNum     uint64
-	logAddrs                                 bool
-	logTopicsStartTxNum, logTopicsEndTxNum   uint64
-	logTopics                                bool
-	tracesFromStartTxNum, tracesFromEndTxNum uint64
-	tracesFrom                               bool
-	tracesToStartTxNum, tracesToEndTxNum     uint64
-	tracesTo                                 bool
+	accounts             DomainRanges
+	storage              DomainRanges
+	code                 DomainRanges
+	commitment           DomainRanges
+	logTopicsEndTxNum    uint64
+	logAddrsEndTxNum     uint64
+	logTopicsStartTxNum  uint64
+	logAddrsStartTxNum   uint64
+	tracesFromStartTxNum uint64
+	tracesFromEndTxNum   uint64
+	tracesToStartTxNum   uint64
+	tracesToEndTxNum     uint64
+	logAddrs             bool
+	logTopics            bool
+	tracesFrom           bool
+	tracesTo             bool
 }
 
 func (r Ranges) any() bool {
@@ -453,26 +456,30 @@ func (a *Aggregator) findMergeRange(maxEndTxNum, maxSpan uint64) Ranges {
 }
 
 type SelectedStaticFiles struct {
-	accounts                      []*filesItem
-	accountsIdx, accountsHist     []*filesItem
-	accountsI                     int
-	storage                       []*filesItem
-	storageIdx, storageHist       []*filesItem
-	storageI                      int
-	code                          []*filesItem
-	codeIdx, codeHist             []*filesItem
-	codeI                         int
-	commitment                    []*filesItem
-	commitmentIdx, commitmentHist []*filesItem
-	commitmentI                   int
-	logAddrs                      []*filesItem
-	logAddrsI                     int
-	logTopics                     []*filesItem
-	logTopicsI                    int
-	tracesFrom                    []*filesItem
-	tracesFromI                   int
-	tracesTo                      []*filesItem
-	tracesToI                     int
+	commitment     []*filesItem
+	logAddrs       []*filesItem
+	accountsHist   []*filesItem
+	codeHist       []*filesItem
+	storage        []*filesItem
+	storageIdx     []*filesItem
+	storageHist    []*filesItem
+	tracesTo       []*filesItem
+	code           []*filesItem
+	codeIdx        []*filesItem
+	tracesFrom     []*filesItem
+	logTopics      []*filesItem
+	commitmentHist []*filesItem
+	commitmentIdx  []*filesItem
+	accounts       []*filesItem
+	accountsIdx    []*filesItem
+	commitmentI    int
+	logAddrsI      int
+	tracesFromI    int
+	logTopicsI     int
+	tracesToI      int
+	codeI          int
+	storageI       int
+	accountsI      int
 }
 
 func (sf SelectedStaticFiles) Close() {
@@ -851,9 +858,9 @@ func (a *Aggregator) SeekCommitment() (uint64, error) {
 }
 
 type commitmentState struct {
+	trieState []byte
 	txNum     uint64
 	blockNum  uint64
-	trieState []byte
 }
 
 func (cs *commitmentState) Decode(buf []byte) error {

--- a/state/aggregator22.go
+++ b/state/aggregator22.go
@@ -228,13 +228,13 @@ func (a *Aggregator22) SetTxNum(txNum uint64) {
 }
 
 type Agg22Collation struct {
-	accounts   HistoryCollation
-	storage    HistoryCollation
-	code       HistoryCollation
 	logAddrs   map[string]*roaring64.Bitmap
 	logTopics  map[string]*roaring64.Bitmap
 	tracesFrom map[string]*roaring64.Bitmap
 	tracesTo   map[string]*roaring64.Bitmap
+	accounts   HistoryCollation
+	storage    HistoryCollation
+	code       HistoryCollation
 }
 
 func (c Agg22Collation) Close() {

--- a/state/aggregator22.go
+++ b/state/aggregator22.go
@@ -35,24 +35,23 @@ import (
 )
 
 type Aggregator22 struct {
-	dir, tmpdir     string
-	aggregationStep uint64
-	accounts        *History
-	storage         *History
-	code            *History
-	logAddrs        *InvertedIndex
-	logTopics       *InvertedIndex
-	tracesFrom      *InvertedIndex
-	tracesTo        *InvertedIndex
-	txNum           uint64
-	logPrefix       string
-	rwTx            kv.RwTx
-	maxTxNum        atomic.Uint64
-
+	rwTx             kv.RwTx
+	db               kv.RoDB
+	storage          *History
+	tracesTo         *InvertedIndex
 	backgroundResult *BackgroundResult
+	code             *History
+	logAddrs         *InvertedIndex
+	logTopics        *InvertedIndex
+	tracesFrom       *InvertedIndex
+	accounts         *History
+	logPrefix        string
+	dir              string
+	tmpdir           string
+	txNum            uint64
+	aggregationStep  uint64
+	maxTxNum         atomic.Uint64
 	working          atomic.Bool
-
-	db kv.RoDB
 }
 
 func NewAggregator22(dir, tmpdir string, aggregationStep uint64, db kv.RoDB) (*Aggregator22, error) {
@@ -641,17 +640,21 @@ func (a *Aggregator22) recalcMaxTxNum() {
 }
 
 type Ranges22 struct {
-	accounts                                 HistoryRanges
-	storage                                  HistoryRanges
-	code                                     HistoryRanges
-	logAddrsStartTxNum, logAddrsEndTxNum     uint64
-	logAddrs                                 bool
-	logTopicsStartTxNum, logTopicsEndTxNum   uint64
-	logTopics                                bool
-	tracesFromStartTxNum, tracesFromEndTxNum uint64
-	tracesFrom                               bool
-	tracesToStartTxNum, tracesToEndTxNum     uint64
-	tracesTo                                 bool
+	accounts             HistoryRanges
+	storage              HistoryRanges
+	code                 HistoryRanges
+	logTopicsStartTxNum  uint64
+	logAddrsEndTxNum     uint64
+	logAddrsStartTxNum   uint64
+	logTopicsEndTxNum    uint64
+	tracesFromStartTxNum uint64
+	tracesFromEndTxNum   uint64
+	tracesToStartTxNum   uint64
+	tracesToEndTxNum     uint64
+	logAddrs             bool
+	logTopics            bool
+	tracesFrom           bool
+	tracesTo             bool
 }
 
 func (r Ranges22) any() bool {
@@ -672,20 +675,23 @@ func (a *Aggregator22) findMergeRange(maxEndTxNum, maxSpan uint64) Ranges22 {
 }
 
 type SelectedStaticFiles22 struct {
-	accountsIdx, accountsHist []*filesItem
-	accountsI                 int
-	storageIdx, storageHist   []*filesItem
-	storageI                  int
-	codeIdx, codeHist         []*filesItem
-	codeI                     int
-	logAddrs                  []*filesItem
-	logAddrsI                 int
-	logTopics                 []*filesItem
-	logTopicsI                int
-	tracesFrom                []*filesItem
-	tracesFromI               int
-	tracesTo                  []*filesItem
-	tracesToI                 int
+	logTopics    []*filesItem
+	accountsHist []*filesItem
+	tracesTo     []*filesItem
+	storageIdx   []*filesItem
+	storageHist  []*filesItem
+	tracesFrom   []*filesItem
+	codeIdx      []*filesItem
+	codeHist     []*filesItem
+	accountsIdx  []*filesItem
+	logAddrs     []*filesItem
+	codeI        int
+	logAddrsI    int
+	logTopicsI   int
+	storageI     int
+	tracesFromI  int
+	accountsI    int
+	tracesToI    int
 }
 
 func (sf SelectedStaticFiles22) Close() {
@@ -1124,8 +1130,8 @@ func (a *Aggregator22) Accounts() *History { return a.accounts }
 func (a *Aggregator22) Storage() *History  { return a.storage }
 
 type Aggregator22Context struct {
+	tx         kv.Tx
 	a          *Aggregator22
-	keyBuf     []byte
 	accounts   *HistoryContext
 	storage    *HistoryContext
 	code       *HistoryContext
@@ -1133,8 +1139,7 @@ type Aggregator22Context struct {
 	logTopics  *InvertedIndexContext
 	tracesFrom *InvertedIndexContext
 	tracesTo   *InvertedIndexContext
-
-	tx kv.Tx
+	keyBuf     []byte
 }
 
 func (a *Aggregator22) MakeContext() *Aggregator22Context {
@@ -1154,8 +1159,8 @@ func (ac *Aggregator22Context) SetTx(tx kv.Tx) { ac.tx = tx }
 // BackgroundResult - used only indicate that some work is done
 // no much reason to pass exact results by this object, just get latest state when need
 type BackgroundResult struct {
-	has bool
 	err error
+	has bool
 }
 
 func (br *BackgroundResult) Has() bool     { return br.has }

--- a/state/domain.go
+++ b/state/domain.go
@@ -50,10 +50,10 @@ var (
 
 // filesItem corresponding to a pair of files (.dat and .idx)
 type filesItem struct {
-	startTxNum   uint64
-	endTxNum     uint64
 	decompressor *compress.Decompressor
 	index        *recsplit.Index
+	startTxNum   uint64
+	endTxNum     uint64
 }
 
 func (i *filesItem) isSubsetOf(j *filesItem) bool {
@@ -88,14 +88,13 @@ func (ds *DomainStats) Accumulate(other DomainStats) {
 // Domain should not have any go routines or locks
 type Domain struct {
 	*History
-	keysTable string // key -> invertedStep , invertedStep = ^(txNum / aggregationStep), Needs to be table with DupSort
-	valsTable string // key + invertedStep -> values
-
 	files       *btree.BTreeG[*filesItem] // Static files pertaining to this domain, items are of type `filesItem`
-	prefixLen   int                       // Number of bytes in the keys that can be used for prefix iteration
-	stats       DomainStats
-	mergesCount uint64
 	defaultDc   *DomainContext
+	keysTable   string // key -> invertedStep , invertedStep = ^(txNum / aggregationStep), Needs to be table with DupSort
+	valsTable   string // key + invertedStep -> values
+	stats       DomainStats
+	prefixLen   int // Number of bytes in the keys that can be used for prefix iteration
+	mergesCount uint64
 }
 
 func NewDomain(
@@ -397,12 +396,14 @@ const (
 // CursorItem is the item in the priority queue used to do merge interation
 // over storage of a given account
 type CursorItem struct {
+	c        kv.CursorDupSort
+	dg       *compress.Getter
+	dg2      *compress.Getter
+	key      []byte
+	val      []byte
+	endTxNum uint64
 	t        CursorType // Whether this item represents state file or DB record, or tree
 	reverse  bool
-	endTxNum uint64
-	key, val []byte
-	dg, dg2  *compress.Getter
-	c        kv.CursorDupSort
 }
 
 type CursorHeap []*CursorItem
@@ -441,10 +442,10 @@ func (ch *CursorHeap) Pop() interface{} {
 
 // filesItem corresponding to a pair of files (.dat and .idx)
 type ctxItem struct {
-	startTxNum uint64
-	endTxNum   uint64
 	getter     *compress.Getter
 	reader     *recsplit.IndexReader
+	startTxNum uint64
+	endTxNum   uint64
 }
 
 func ctxItemLess(i, j ctxItem) bool {
@@ -592,13 +593,13 @@ func (dc *DomainContext) IteratePrefix(prefix []byte, it func(k, v []byte)) erro
 
 // Collation is the set of compressors created after aggregation
 type Collation struct {
-	valuesPath   string
 	valuesComp   *compress.Compressor
-	valuesCount  int
-	historyPath  string
 	historyComp  *compress.Compressor
-	historyCount int
 	indexBitmaps map[string]*roaring64.Bitmap
+	valuesPath   string
+	historyPath  string
+	valuesCount  int
+	historyCount int
 }
 
 func (c Collation) Close() {

--- a/state/history.go
+++ b/state/history.go
@@ -47,13 +47,12 @@ import (
 
 type History struct {
 	*InvertedIndex
+	files            *btree.BTreeG[*filesItem]
+	w                *historyWriter
 	historyValsTable string // key1+key2+txnNum -> oldValue , stores values BEFORE change
 	settingsTable    string
-	files            *btree.BTreeG[*filesItem]
-	compressVals     bool
 	workers          int
-
-	w *historyWriter
+	compressVals     bool
 }
 
 func NewHistory(
@@ -434,9 +433,9 @@ func (h *History) Flush() error {
 
 type historyWriter struct {
 	h                *History
-	autoIncrement    uint64
-	autoIncrementBuf []byte
 	tmpdir           string
+	autoIncrementBuf []byte
+	autoIncrement    uint64
 }
 
 func (h *historyWriter) close() {
@@ -527,10 +526,10 @@ func (h *historyWriter) addPrevValue(key1, key2, original []byte) error {
 }
 
 type HistoryCollation struct {
-	historyPath  string
 	historyComp  *compress.Compressor
-	historyCount int
 	indexBitmaps map[string]*roaring64.Bitmap
+	historyPath  string
+	historyCount int
 }
 
 func (c HistoryCollation) Close() {
@@ -1148,21 +1147,30 @@ func (hc *HistoryContext) IterateChanged(startTxNum, endTxNum uint64, roTx kv.Tx
 }
 
 type HistoryIterator1 struct {
-	hc           *HistoryContext
-	compressVals bool
-	total        uint64
-
-	hasNextInFiles                      bool
-	hasNextInDb                         bool
-	startTxKey, txnKey                  [8]byte
-	startTxNum, endTxNum                uint64
-	roTx                                kv.Tx
-	idxCursor, txNum2kCursor            kv.CursorDupSort
-	indexTable, idxKeysTable, valsTable string
-	h                                   ReconHeap
-
-	nextKey, nextVal, nextFileKey, nextFileVal, nextDbKey, nextDbVal []byte
-	advFileCnt, advDbCnt                                             int
+	roTx           kv.Tx
+	txNum2kCursor  kv.CursorDupSort
+	idxCursor      kv.CursorDupSort
+	hc             *HistoryContext
+	valsTable      string
+	idxKeysTable   string
+	indexTable     string
+	nextFileKey    []byte
+	nextDbKey      []byte
+	nextDbVal      []byte
+	nextFileVal    []byte
+	nextVal        []byte
+	nextKey        []byte
+	h              ReconHeap
+	total          uint64
+	endTxNum       uint64
+	startTxNum     uint64
+	advFileCnt     int
+	advDbCnt       int
+	startTxKey     [8]byte
+	txnKey         [8]byte
+	hasNextInFiles bool
+	hasNextInDb    bool
+	compressVals   bool
 }
 
 func (hi *HistoryIterator1) Stat() (int, int) { return hi.advDbCnt, hi.advFileCnt }

--- a/state/inverted_index.go
+++ b/state/inverted_index.go
@@ -44,19 +44,17 @@ import (
 )
 
 type InvertedIndex struct {
-	indexKeysTable string // txnNum_u64 -> key (k+auto_increment)
-	indexTable     string // k -> txnNum_u64 , Needs to be table with DupSort
-
-	dir             string // Directory where static files are created
-	aggregationStep uint64
-	filenameBase    string
 	tx              kv.RwTx
-	txNum           uint64
-	txNumBytes      [8]byte
 	files           *btree.BTreeG[*filesItem]
-
-	workers int
-	w       *invertedIndexWriter
+	w               *invertedIndexWriter
+	indexKeysTable  string // txnNum_u64 -> key (k+auto_increment)
+	indexTable      string // k -> txnNum_u64 , Needs to be table with DupSort
+	dir             string // Directory where static files are created
+	filenameBase    string
+	aggregationStep uint64
+	txNum           uint64
+	workers         int
+	txNumBytes      [8]byte
 }
 
 func NewInvertedIndex(
@@ -387,16 +385,17 @@ func (ii *InvertedIndex) MakeContext() *InvertedIndexContext {
 // a requirement for interators to be composable (for example, to implement AND and OR for indices)
 // InvertedIterator must be closed after use to prevent leaking of resources like cursor
 type InvertedIterator struct {
-	key                  []byte
-	startTxNum, endTxNum uint64
-	stack                []ctxItem
-	efIt                 *eliasfano32.EliasFanoIter
-	next                 uint64
-	hasNextInFiles       bool
-	hasNextInDb          bool
-	roTx                 kv.Tx
-	indexTable           string
-	cursor               kv.CursorDupSort
+	roTx           kv.Tx
+	cursor         kv.CursorDupSort
+	efIt           *eliasfano32.EliasFanoIter
+	indexTable     string
+	key            []byte
+	stack          []ctxItem
+	startTxNum     uint64
+	endTxNum       uint64
+	next           uint64
+	hasNextInFiles bool
+	hasNextInDb    bool
 }
 
 func (it *InvertedIterator) Close() {
@@ -539,16 +538,19 @@ func (ic *InvertedIndexContext) IterateRange(key []byte, startTxNum, endTxNum ui
 }
 
 type InvertedIterator1 struct {
-	hasNextInFiles                       bool
-	hasNextInDb                          bool
-	startTxKey                           [8]byte
-	startTxNum                           uint64
-	endTxNum                             uint64
-	roTx                                 kv.Tx
-	cursor                               kv.CursorDupSort
-	indexTable                           string
-	h                                    ReconHeap
-	key, nextKey, nextFileKey, nextDbKey []byte
+	roTx           kv.Tx
+	cursor         kv.CursorDupSort
+	indexTable     string
+	key            []byte
+	h              ReconHeap
+	nextKey        []byte
+	nextFileKey    []byte
+	nextDbKey      []byte
+	endTxNum       uint64
+	startTxNum     uint64
+	startTxKey     [8]byte
+	hasNextInDb    bool
+	hasNextInFiles bool
 }
 
 func (it *InvertedIterator1) Close() {

--- a/state/inverted_index.go
+++ b/state/inverted_index.go
@@ -52,7 +52,7 @@ type InvertedIndex struct {
 	indexKeysTable  string // txnNum_u64 -> key (k+auto_increment)
 	indexTable      string // k -> txnNum_u64 , Needs to be table with DupSort
 	dir             string // Directory where static files are created
-  tmpdir     string // Directory where static files are created
+	tmpdir          string // Directory where static files are created
 	filenameBase    string
 	aggregationStep uint64
 	txNum           uint64

--- a/state/merge.go
+++ b/state/merge.go
@@ -69,12 +69,12 @@ func (h *History) endTxNumMinimax() uint64 {
 type DomainRanges struct {
 	valuesStartTxNum  uint64
 	valuesEndTxNum    uint64
-	values            bool
 	historyStartTxNum uint64
 	historyEndTxNum   uint64
-	history           bool
 	indexStartTxNum   uint64
 	indexEndTxNum     uint64
+	values            bool
+	history           bool
 	index             bool
 }
 
@@ -143,9 +143,9 @@ func (ii *InvertedIndex) findMergeRange(maxEndTxNum, maxSpan uint64) (bool, uint
 type HistoryRanges struct {
 	historyStartTxNum uint64
 	historyEndTxNum   uint64
-	history           bool
 	indexStartTxNum   uint64
 	indexEndTxNum     uint64
+	history           bool
 	index             bool
 }
 

--- a/state/read_indices.go
+++ b/state/read_indices.go
@@ -27,13 +27,13 @@ import (
 )
 
 type ReadIndices struct {
-	aggregationStep uint64
+	rwTx            kv.RwTx
 	accounts        *InvertedIndex
 	storage         *InvertedIndex
 	code            *InvertedIndex
-	txNum           uint64
-	rwTx            kv.RwTx
 	keyBuf          []byte
+	aggregationStep uint64
+	txNum           uint64
 }
 
 func NewReadIndices(
@@ -209,12 +209,15 @@ func (ri *ReadIndices) endTxNumMinimax() uint64 {
 }
 
 type RRanges struct {
-	accountsStartTxNum, accountsEndTxNum uint64
-	accounts                             bool
-	storageStartTxNum, storageEndTxNum   uint64
-	storage                              bool
-	codeStartTxNum, codeEndTxNum         uint64
-	code                                 bool
+	accountsStartTxNum uint64
+	accountsEndTxNum   uint64
+	storageStartTxNum  uint64
+	storageEndTxNum    uint64
+	codeStartTxNum     uint64
+	codeEndTxNum       uint64
+	accounts           bool
+	storage            bool
+	code               bool
 }
 
 func (r RRanges) any() bool {
@@ -232,10 +235,10 @@ func (ri *ReadIndices) findMergeRange(maxEndTxNum, maxSpan uint64) RRanges {
 
 type RSelectedStaticFiles struct {
 	accounts  []*filesItem
-	accountsI int
 	storage   []*filesItem
-	storageI  int
 	code      []*filesItem
+	accountsI int
+	storageI  int
 	codeI     int
 }
 

--- a/state/state_recon.go
+++ b/state/state_recon.go
@@ -59,11 +59,11 @@ func (hc *HistoryContext) IsMaxTxNum(key []byte, txNum uint64) bool {
 }
 
 type ReconItem struct {
+	g           *compress.Getter
 	key         []byte
 	txNum       uint64
 	startTxNum  uint64
 	endTxNum    uint64
-	g           *compress.Getter
 	startOffset uint64
 	lastOffset  uint64
 }
@@ -110,16 +110,17 @@ func (rh *ReconHeap) Pop() interface{} {
 }
 
 type ScanIterator struct {
-	hc             *HistoryContext
-	h              ReconHeap
-	uptoTxNum      uint64
-	hasNext        bool
-	nextTxNum      uint64
-	nextKey        []byte
-	fromKey, toKey []byte
-	key            []byte
-	progress       uint64
-	total          uint64
+	hc        *HistoryContext
+	h         ReconHeap
+	nextKey   []byte
+	fromKey   []byte
+	toKey     []byte
+	key       []byte
+	uptoTxNum uint64
+	nextTxNum uint64
+	progress  uint64
+	total     uint64
+	hasNext   bool
 }
 
 func (si *ScanIterator) advance() {
@@ -188,15 +189,17 @@ func (hc *HistoryContext) iterateReconTxs(fromKey, toKey []byte, uptoTxNum uint6
 }
 
 type HistoryIterator struct {
-	hc             *HistoryContext
-	h              ReconHeap
-	txNum          uint64
-	key, val       []byte
-	hasNext        bool
-	compressVals   bool
-	fromKey, toKey []byte
-	progress       uint64
-	total          uint64
+	hc           *HistoryContext
+	h            ReconHeap
+	key          []byte
+	val          []byte
+	fromKey      []byte
+	toKey        []byte
+	txNum        uint64
+	progress     uint64
+	total        uint64
+	hasNext      bool
+	compressVals bool
 }
 
 func (hi *HistoryIterator) advance() {

--- a/txpool/fetch.go
+++ b/txpool/fetch.go
@@ -41,17 +41,16 @@ import (
 // genesis hash and list of forks, but with zero max block and total difficulty
 // Sentry should have a logic not to overwrite statusData with messages from tx pool
 type Fetch struct {
-	ctx                context.Context       // Context used for cancellation and closing of the fetcher
-	sentryClients      []direct.SentryClient // sentry clients that will be used for accessing the network
-	pool               Pool                  // Transaction pool implementation
-	coreDB             kv.RoDB
-	db                 kv.RwDB
-	wg                 *sync.WaitGroup // used for synchronisation in the tests (nil when not in tests)
-	stateChangesClient StateChangesClient
-
+	ctx                      context.Context // Context used for cancellation and closing of the fetcher
+	pool                     Pool            // Transaction pool implementation
+	coreDB                   kv.RoDB
+	db                       kv.RwDB
+	stateChangesClient       StateChangesClient
+	wg                       *sync.WaitGroup // used for synchronisation in the tests (nil when not in tests)
 	stateChangesParseCtx     *types2.TxParseContext
-	stateChangesParseCtxLock sync.Mutex
 	pooledTxsParseCtx        *types2.TxParseContext
+	sentryClients            []direct.SentryClient // sentry clients that will be used for accessing the network
+	stateChangesParseCtxLock sync.Mutex
 	pooledTxsParseCtxLock    sync.Mutex
 }
 

--- a/txpool/mocks_test.go
+++ b/txpool/mocks_test.go
@@ -17,40 +17,40 @@ var _ Pool = &PoolMock{}
 
 // PoolMock is a mock implementation of Pool.
 //
-// 	func TestSomethingThatUsesPool(t *testing.T) {
+//	func TestSomethingThatUsesPool(t *testing.T) {
 //
-// 		// make and configure a mocked Pool
-// 		mockedPool := &PoolMock{
-// 			AddLocalTxsFunc: func(ctx context.Context, newTxs types2.TxSlots, tx kv.Tx) ([]DiscardReason, error) {
-// 				panic("mock out the AddLocalTxs method")
-// 			},
-// 			AddNewGoodPeerFunc: func(peerID types2.PeerID)  {
-// 				panic("mock out the AddNewGoodPeer method")
-// 			},
-// 			AddRemoteTxsFunc: func(ctx context.Context, newTxs types2.TxSlots)  {
-// 				panic("mock out the AddRemoteTxs method")
-// 			},
-// 			GetRlpFunc: func(tx kv.Tx, hash []byte) ([]byte, error) {
-// 				panic("mock out the GetRlp method")
-// 			},
-// 			IdHashKnownFunc: func(tx kv.Tx, hash []byte) (bool, error) {
-// 				panic("mock out the IdHashKnown method")
-// 			},
-// 			OnNewBlockFunc: func(ctx context.Context, stateChanges *remote.StateChangeBatch, unwindTxs types2.TxSlots, minedTxs types2.TxSlots, tx kv.Tx) error {
-// 				panic("mock out the OnNewBlock method")
-// 			},
-// 			StartedFunc: func() bool {
-// 				panic("mock out the Started method")
-// 			},
-// 			ValidateSerializedTxnFunc: func(serializedTxn []byte) error {
-// 				panic("mock out the ValidateSerializedTxn method")
-// 			},
-// 		}
+//		// make and configure a mocked Pool
+//		mockedPool := &PoolMock{
+//			AddLocalTxsFunc: func(ctx context.Context, newTxs types2.TxSlots, tx kv.Tx) ([]DiscardReason, error) {
+//				panic("mock out the AddLocalTxs method")
+//			},
+//			AddNewGoodPeerFunc: func(peerID types2.PeerID)  {
+//				panic("mock out the AddNewGoodPeer method")
+//			},
+//			AddRemoteTxsFunc: func(ctx context.Context, newTxs types2.TxSlots)  {
+//				panic("mock out the AddRemoteTxs method")
+//			},
+//			GetRlpFunc: func(tx kv.Tx, hash []byte) ([]byte, error) {
+//				panic("mock out the GetRlp method")
+//			},
+//			IdHashKnownFunc: func(tx kv.Tx, hash []byte) (bool, error) {
+//				panic("mock out the IdHashKnown method")
+//			},
+//			OnNewBlockFunc: func(ctx context.Context, stateChanges *remote.StateChangeBatch, unwindTxs types2.TxSlots, minedTxs types2.TxSlots, tx kv.Tx) error {
+//				panic("mock out the OnNewBlock method")
+//			},
+//			StartedFunc: func() bool {
+//				panic("mock out the Started method")
+//			},
+//			ValidateSerializedTxnFunc: func(serializedTxn []byte) error {
+//				panic("mock out the ValidateSerializedTxn method")
+//			},
+//		}
 //
-// 		// use mockedPool in code that requires Pool
-// 		// and then make assertions.
+//		// use mockedPool in code that requires Pool
+//		// and then make assertions.
 //
-// 	}
+//	}
 type PoolMock struct {
 	// AddLocalTxsFunc mocks the AddLocalTxs method.
 	AddLocalTxsFunc func(ctx context.Context, newTxs types2.TxSlots, tx kv.Tx) ([]DiscardReason, error)
@@ -171,7 +171,8 @@ func (mock *PoolMock) AddLocalTxs(ctx context.Context, newTxs types2.TxSlots, tx
 
 // AddLocalTxsCalls gets all the calls that were made to AddLocalTxs.
 // Check the length with:
-//     len(mockedPool.AddLocalTxsCalls())
+//
+//	len(mockedPool.AddLocalTxsCalls())
 func (mock *PoolMock) AddLocalTxsCalls() []struct {
 	Ctx    context.Context
 	NewTxs types2.TxSlots
@@ -206,7 +207,8 @@ func (mock *PoolMock) AddNewGoodPeer(peerID types2.PeerID) {
 
 // AddNewGoodPeerCalls gets all the calls that were made to AddNewGoodPeer.
 // Check the length with:
-//     len(mockedPool.AddNewGoodPeerCalls())
+//
+//	len(mockedPool.AddNewGoodPeerCalls())
 func (mock *PoolMock) AddNewGoodPeerCalls() []struct {
 	PeerID types2.PeerID
 } {
@@ -239,7 +241,8 @@ func (mock *PoolMock) AddRemoteTxs(ctx context.Context, newTxs types2.TxSlots) {
 
 // AddRemoteTxsCalls gets all the calls that were made to AddRemoteTxs.
 // Check the length with:
-//     len(mockedPool.AddRemoteTxsCalls())
+//
+//	len(mockedPool.AddRemoteTxsCalls())
 func (mock *PoolMock) AddRemoteTxsCalls() []struct {
 	Ctx    context.Context
 	NewTxs types2.TxSlots
@@ -278,7 +281,8 @@ func (mock *PoolMock) GetRlp(tx kv.Tx, hash []byte) ([]byte, error) {
 
 // GetRlpCalls gets all the calls that were made to GetRlp.
 // Check the length with:
-//     len(mockedPool.GetRlpCalls())
+//
+//	len(mockedPool.GetRlpCalls())
 func (mock *PoolMock) GetRlpCalls() []struct {
 	Tx   kv.Tx
 	Hash []byte
@@ -317,7 +321,8 @@ func (mock *PoolMock) IdHashKnown(tx kv.Tx, hash []byte) (bool, error) {
 
 // IdHashKnownCalls gets all the calls that were made to IdHashKnown.
 // Check the length with:
-//     len(mockedPool.IdHashKnownCalls())
+//
+//	len(mockedPool.IdHashKnownCalls())
 func (mock *PoolMock) IdHashKnownCalls() []struct {
 	Tx   kv.Tx
 	Hash []byte
@@ -361,7 +366,8 @@ func (mock *PoolMock) OnNewBlock(ctx context.Context, stateChanges *remote.State
 
 // OnNewBlockCalls gets all the calls that were made to OnNewBlock.
 // Check the length with:
-//     len(mockedPool.OnNewBlockCalls())
+//
+//	len(mockedPool.OnNewBlockCalls())
 func (mock *PoolMock) OnNewBlockCalls() []struct {
 	Ctx          context.Context
 	StateChanges *remote.StateChangeBatch
@@ -400,7 +406,8 @@ func (mock *PoolMock) Started() bool {
 
 // StartedCalls gets all the calls that were made to Started.
 // Check the length with:
-//     len(mockedPool.StartedCalls())
+//
+//	len(mockedPool.StartedCalls())
 func (mock *PoolMock) StartedCalls() []struct {
 } {
 	var calls []struct {
@@ -432,7 +439,8 @@ func (mock *PoolMock) ValidateSerializedTxn(serializedTxn []byte) error {
 
 // ValidateSerializedTxnCalls gets all the calls that were made to ValidateSerializedTxn.
 // Check the length with:
-//     len(mockedPool.ValidateSerializedTxnCalls())
+//
+//	len(mockedPool.ValidateSerializedTxnCalls())
 func (mock *PoolMock) ValidateSerializedTxnCalls() []struct {
 	SerializedTxn []byte
 } {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -68,19 +68,17 @@ const ASSERT = false
 
 type Config struct {
 	DBDir                 string
+	TracedSenders         []string // List of senders for which tx pool should print out debugging info
 	SyncToNewPeersEvery   time.Duration
 	ProcessRemoteTxsEvery time.Duration
 	CommitEvery           time.Duration
 	LogEvery              time.Duration
-
-	PendingSubPoolLimit int
-	BaseFeeSubPoolLimit int
-	QueuedSubPoolLimit  int
-
-	MinFeeCap     uint64
-	AccountSlots  uint64   // Number of executable transaction slots guaranteed per account
-	PriceBump     uint64   // Price bump percentage to replace an already existing transaction
-	TracedSenders []string // List of senders for which tx pool should print out debugging info
+	PendingSubPoolLimit   int
+	BaseFeeSubPoolLimit   int
+	QueuedSubPoolLimit    int
+	MinFeeCap             uint64
+	AccountSlots          uint64 // Number of executable transaction slots guaranteed per account
+	PriceBump             uint64 // Price bump percentage to replace an already existing transaction
 }
 
 var DefaultConfig = Config{
@@ -220,15 +218,15 @@ func (r DiscardReason) String() string {
 // metaTx holds transaction and some metadata
 type metaTx struct {
 	Tx                        *types.TxSlot
-	subPool                   SubPoolMarker
+	minFeeCap                 uint256.Int
 	nonceDistance             uint64 // how far their nonces are from the state's nonce for the sender
 	cumulativeBalanceDistance uint64 // how far their cumulativeRequiredBalance are from the state's balance for the sender
-	minFeeCap                 uint256.Int
 	minTip                    uint64
 	bestIndex                 int
 	worstIndex                int
-	currentSubPool            SubPoolType
 	timestamp                 uint64 // when it was added to pool
+	subPool                   SubPoolMarker
+	currentSubPool            SubPoolType
 }
 
 func newMetaTx(slot *types.TxSlot, isLocal bool, timestmap uint64) *metaTx {
@@ -289,38 +287,34 @@ func calcProtocolBaseFee(baseFee uint64) uint64 {
 //
 // It preserve TxSlot objects immutable
 type TxPool struct {
-	lock *sync.RWMutex
-
-	started        atomic.Bool
-	lastSeenBlock  atomic.Uint64
-	pendingBaseFee atomic.Uint64
-	blockGasLimit  atomic.Uint64
-
+	_chainDB      kv.RoDB // remote db - use it wisely
+	_stateCache   kvcache.Cache
+	baseFee       *SubPool
+	newPendingTxs chan types.Hashes // notifications about new txs in Pending sub-pool
+	senders       *sendersBatch
 	// batch processing of remote transactions
 	// handling works fast without batching, but batching allow:
 	//   - reduce amount of _chainDB transactions
 	//   - batch notifications about new txs (reduce P2P spam to other nodes about txs propagation)
 	//   - and as a result reducing pool.RWLock contention
 	unprocessedRemoteTxs    *types.TxSlots
-	unprocessedRemoteByHash map[string]int // to reject duplicates
-
-	byHash            map[string]*metaTx // tx_hash => tx : only not committed to db yet records
-	discardReasonsLRU *simplelru.LRU     // tx_hash => discard_reason : non-persisted
-	pending           *PendingPool
-	baseFee, queued   *SubPool
-	isLocalLRU        *simplelru.LRU    // tx_hash => is_local : to restore isLocal flag of unwinded transactions
-	newPendingTxs     chan types.Hashes // notifications about new txs in Pending sub-pool
-	deletedTxs        []*metaTx         // list of discarded txs since last db commit
-	all               *BySenderAndNonce // senderID => (sorted map of tx nonce => *metaTx)
-	promoted          types.Hashes      // pre-allocated temporary buffer to write promoted to pending pool txn hashes
-	_chainDB          kv.RoDB           // remote db - use it wisely
-	_stateCache       kvcache.Cache
-	cfg               Config
-
-	recentlyConnectedPeers *recentlyConnectedPeers // all txs will be propagated to this peers eventually, and clear list
-	senders                *sendersBatch
-
-	chainID uint256.Int
+	unprocessedRemoteByHash map[string]int     // to reject duplicates
+	byHash                  map[string]*metaTx // tx_hash => tx : only not committed to db yet records
+	discardReasonsLRU       *simplelru.LRU     // tx_hash => discard_reason : non-persisted
+	pending                 *PendingPool
+	lock                    *sync.RWMutex
+	queued                  *SubPool
+	isLocalLRU              *simplelru.LRU          // tx_hash => is_local : to restore isLocal flag of unwinded transactions
+	recentlyConnectedPeers  *recentlyConnectedPeers // all txs will be propagated to this peers eventually, and clear list
+	all                     *BySenderAndNonce       // senderID => (sorted map of tx nonce => *metaTx)
+	cfg                     Config
+	deletedTxs              []*metaTx    // list of discarded txs since last db commit
+	promoted                types.Hashes // pre-allocated temporary buffer to write promoted to pending pool txn hashes
+	chainID                 uint256.Int
+	lastSeenBlock           atomic.Uint64
+	started                 atomic.Bool
+	pendingBaseFee          atomic.Uint64
+	blockGasLimit           atomic.Uint64
 }
 
 func New(newTxs chan types.Hashes, coreDB kv.RoDB, cfg Config, cache kvcache.Cache, chainID uint256.Int) (*TxPool, error) {
@@ -1787,8 +1781,8 @@ var PoolPendingBaseFeeKey = []byte("pending_base_fee")
 // DoS protection and performance saving
 // it doesn't track if peer disconnected, it's fine
 type recentlyConnectedPeers struct {
-	lock  sync.RWMutex
 	peers []types.PeerID
+	lock  sync.RWMutex
 }
 
 func (l *recentlyConnectedPeers) AddPeer(p types.PeerID) {
@@ -1817,10 +1811,10 @@ func (sc *sendersBatch) printDebug(prefix string) {
 // flushing to db periodicaly. it doesn't play as read-cache (because db is small and memory-mapped - doesn't need cache)
 // non thread-safe
 type sendersBatch struct {
-	senderID      uint64
 	senderIDs     map[string]uint64
 	senderID2Addr map[uint64][]byte
 	tracedSenders map[string]struct{}
+	senderID      uint64
 }
 
 func newSendersCache(tracedSenders map[string]struct{}) *sendersBatch {
@@ -1992,12 +1986,12 @@ func (b *BySenderAndNonce) replaceOrInsert(mt *metaTx) *metaTx {
 // It's more expensive to maintain "slice sort" invariant, but it allow do cheap copy of
 // pending.best slice for mining (because we consider txs and metaTx are immutable)
 type PendingPool struct {
-	limit  int
-	t      SubPoolType
 	best   *bestSlice
 	worst  *WorstQueue
-	adding bool
 	added  types.Hashes
+	limit  int
+	t      SubPoolType
+	adding bool
 }
 
 func NewPendingSubPool(t SubPoolType, limit int) *PendingPool {
@@ -2100,12 +2094,12 @@ func (p *PendingPool) DebugPrint(prefix string) {
 }
 
 type SubPool struct {
-	limit  int
-	t      SubPoolType
 	best   *BestQueue
 	worst  *WorstQueue
-	adding bool
 	added  types.Hashes
+	limit  int
+	t      SubPoolType
+	adding bool
 }
 
 func NewSubPool(t SubPoolType, limit int) *SubPool {

--- a/txpool/send.go
+++ b/txpool/send.go
@@ -36,10 +36,9 @@ type SentryClient interface {
 // does not initiate any messages by self
 type Send struct {
 	ctx           context.Context
-	sentryClients []direct.SentryClient // sentry clients that will be used for accessing the network
 	pool          Pool
-
-	wg *sync.WaitGroup
+	wg            *sync.WaitGroup
+	sentryClients []direct.SentryClient // sentry clients that will be used for accessing the network
 }
 
 func NewSend(ctx context.Context, sentryClients []direct.SentryClient, pool Pool) *Send {

--- a/txpool/test_util.go
+++ b/txpool/test_util.go
@@ -29,11 +29,11 @@ import (
 //go:generate moq -stub -out mocks_test.go . Pool
 
 type MockSentry struct {
+	ctx context.Context
 	*sentry.SentryServerMock
 	streams      map[sentry.MessageId][]sentry.Sentry_MessagesServer
 	peersStreams []sentry.Sentry_PeerEventsServer
 	StreamWg     sync.WaitGroup
-	ctx          context.Context
 	lock         sync.RWMutex
 }
 

--- a/types/testdata.go
+++ b/types/testdata.go
@@ -79,8 +79,8 @@ var txRopstenTests = []parseTxTest{
 }
 
 var allNetsTestCases = []struct {
-	chainID uint256.Int
 	tests   []parseTxTest
+	chainID uint256.Int
 }{
 	{
 		chainID: *uint256.NewInt(1),


### PR DESCRIPTION
```
➜  erigon-lib git:(fieldalign) ✗ fieldalignment -fix ./...
/Users/estensen/Developer/erigon-lib/commitment/bin_patricia_hashed.go:81:16: struct of size 1065120 could be 1065112
/Users/estensen/Developer/erigon-lib/commitment/bin_patricia_hashed.go:1063:14: struct of size 1032 could be 1024
/Users/estensen/Developer/erigon-lib/commitment/hex_patricia_hashed.go:62:24: struct of size 952776 could be 952768
/Users/estensen/Developer/erigon-lib/commitment/hex_patricia_hashed.go:98:12: struct of size 1832 could be 1824
/Users/estensen/Developer/erigon-lib/commitment/hex_patricia_hashed.go:113:12: struct with 208 pointer bytes could be 152
/Users/estensen/Developer/erigon-lib/commitment/hex_patricia_hashed.go:143:11: struct of size 464 could be 456
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:24:11: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:79:11: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:134:11: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:189:11: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:244:12: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:299:12: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:355:19: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:418:23: struct with 168 pointer bytes could be 128
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:571:20: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:626:20: struct with 136 pointer bytes could be 128
/Users/estensen/Developer/erigon-lib/gointerfaces/types/types.pb.go:721:15: struct of size 168 could be 160
/Users/estensen/Developer/erigon-lib/etl/buffers.go:75:21: struct with 88 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/etl/buffers.go:182:27: struct with 56 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/etl/buffers.go:274:32: struct with 56 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/etl/collector.go:41:16: struct with 72 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/etl/etl.go:66:20: struct with 96 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/etl/heap.go:25:15: struct with 40 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/patricia/patricia.go:29:11: struct with 40 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/patricia/patricia.go:347:12: struct with 32 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/patricia/patricia.go:367:18: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/patricia/patricia.go:377:19: struct with 168 pointer bytes could be 144
/Users/estensen/Developer/erigon-lib/compress/compress.go:52:17: struct with 176 pointer bytes could be 136
/Users/estensen/Developer/erigon-lib/compress/compress.go:241:24: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/compress/compress.go:327:14: struct with 40 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/compress/compress.go:353:18: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/compress/compress.go:450:19: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/compress/compress.go:670:21: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/compress/compress.go:734:23: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/compress/decompress.go:31:15: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/compress/decompress.go:39:19: struct with 40 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/compress/decompress.go:117:15: struct with 64 pointer bytes could be 56
/Users/estensen/Developer/erigon-lib/compress/decompress.go:125:19: struct with 96 pointer bytes could be 80
/Users/estensen/Developer/erigon-lib/compress/decompress.go:386:13: struct with 64 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/compress/parallel_compress.go:208:22: struct with 16 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/recsplit/golomb_rice.go:32:17: struct with 16 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/recsplit/index.go:35:12: struct of size 432 could be 424
/Users/estensen/Developer/erigon-lib/recsplit/index_reader.go:26:18: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/recsplit/recsplit.go:64:15: struct of size 704 could be 680
/Users/estensen/Developer/erigon-lib/recsplit/recsplit.go:111:19: struct of size 104 could be 96
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:171:17: struct of size 640 could be 632
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:198:17: struct with 168 pointer bytes could be 144
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:389:14: struct with 584 pointer bytes could be 568
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:921:21: struct with 72 pointer bytes could be 56
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:1195:22: struct with 2432 pointer bytes could be 2416
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:2123:13: struct with 2448 pointer bytes could be 2416
/Users/estensen/Developer/erigon-lib/aggregator/aggregator.go:2634:17: struct with 96 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/aggregator/history.go:39:14: struct with 96 pointer bytes could be 88
/Users/estensen/Developer/erigon-lib/bptree/binary_file.go:33:17: struct with 40 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/bptree/node.go:79:13: struct of size 88 could be 80
/Users/estensen/Developer/erigon-lib/chain/chain_config.go:28:13: struct with 136 pointer bytes could be 120
/Users/estensen/Developer/erigon-lib/common/background/progress.go:26:18: struct with 40 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/gointerfaces/downloader/downloader.pb.go:25:19: struct with 64 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/downloader/downloader.pb.go:80:22: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/downloader/downloader.pb.go:127:20: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/downloader/downloader.pb.go:165:19: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/downloader/downloader.pb.go:203:17: struct of size 104 could be 96
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:135:23: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:173:21: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:220:24: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:258:22: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:305:26: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:343:24: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:390:30: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:437:26: struct of size 72 could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:500:30: struct with 64 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:563:28: struct with 64 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:626:37: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:681:35: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:736:29: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:774:27: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:821:27: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:859:25: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:906:23: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:953:21: struct of size 72 could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1008:24: struct of size 104 could be 88
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1079:25: struct of size 144 could be 136
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1190:19: struct with 56 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1245:17: struct with 72 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1300:23: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1347:21: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1394:23: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1441:21: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1488:17: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/ethbackend.pb.go:1535:24: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:220:13: struct of size 120 could be 112
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:299:11: struct of size 104 could be 96
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:370:20: struct with 56 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:425:20: struct of size 136 could be 128
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:513:23: struct with 56 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:585:18: struct of size 112 could be 104
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:664:25: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:719:23: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/remote/kv.pb.go:757:21: struct with 72 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:300:26: struct of size 72 could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:355:35: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:410:29: struct with 56 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:465:38: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:520:16: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:567:26: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:622:26: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:677:21: struct of size 80 could be 72
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:740:12: struct with 56 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:795:17: struct with 72 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:874:21: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:912:21: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:959:22: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1006:17: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1053:23: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1091:21: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1138:22: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1185:20: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1232:24: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/sentry/sentry.pb.go:1270:16: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:25:28: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:63:26: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:110:26: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:148:24: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:195:27: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:233:25: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:280:21: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:318:19: struct with 96 pointer bytes could be 80
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:389:24: struct with 96 pointer bytes could be 88
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:452:22: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:499:28: struct with 56 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:554:26: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:601:22: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:639:20: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:686:20: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/mining.pb.go:724:18: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:132:15: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:179:17: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:226:15: struct with 72 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:281:26: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:328:24: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:375:19: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:413:17: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:460:17: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:498:15: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:545:19: struct with 48 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:592:20: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:630:18: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:693:19: struct with 48 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:740:17: struct of size 56 could be 48
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:795:18: struct of size 80 could be 72
/Users/estensen/Developer/erigon-lib/gointerfaces/txpool/txpool.pb.go:858:22: struct of size 80 could be 72
/Users/estensen/Developer/erigon-lib/direct/sentry_client.go:171:25: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/kv/mdbx/kv_mdbx.go:50:15: struct with 104 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/kv/mdbx/kv_mdbx.go:355:13: struct with 160 pointer bytes could be 152
/Users/estensen/Developer/erigon-lib/kv/memdb/memory_mutation_cursor.go:39:27: struct with 200 pointer bytes could be 184
/Users/estensen/Developer/erigon-lib/kv/remotedb/kv_remote.go:22:17: struct with 72 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/kv/remotedb/kv_remote.go:38:15: struct with 80 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/kv/remotedbserver/server.go:314:24: struct with 40 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/state/aggregator.go:44:17: struct with 192 pointer bytes could be 128
/Users/estensen/Developer/erigon-lib/state/aggregator.go:422:13: struct of size 384 could be 360
/Users/estensen/Developer/erigon-lib/state/aggregator.go:455:26: struct with 424 pointer bytes could be 368
/Users/estensen/Developer/erigon-lib/state/aggregator.go:853:22: struct with 24 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/state/aggregator22.go:37:19: struct with 176 pointer bytes could be 136
/Users/estensen/Developer/erigon-lib/state/aggregator22.go:643:15: struct of size 240 could be 216
/Users/estensen/Developer/erigon-lib/state/aggregator22.go:674:28: struct with 272 pointer bytes could be 224
/Users/estensen/Developer/erigon-lib/state/aggregator22.go:1126:26: struct with 104 pointer bytes could be 88
/Users/estensen/Developer/erigon-lib/state/aggregator22.go:1156:23: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/state/domain.go:52:16: struct with 32 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/state/domain.go:89:13: struct with 120 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/state/domain.go:399:17: struct with 96 pointer bytes could be 64
/Users/estensen/Developer/erigon-lib/state/domain.go:443:14: struct with 32 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/state/domain.go:594:16: struct with 72 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/state/history.go:48:14: struct with 72 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/state/history.go:435:20: struct with 48 pointer bytes could be 32
/Users/estensen/Developer/erigon-lib/state/history.go:529:23: struct with 40 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/state/history.go:1150:23: struct of size 344 could be 336
/Users/estensen/Developer/erigon-lib/state/inverted_index.go:46:20: struct with 128 pointer bytes could be 88
/Users/estensen/Developer/erigon-lib/state/inverted_index.go:389:23: struct with 136 pointer bytes could be 88
/Users/estensen/Developer/erigon-lib/state/inverted_index.go:541:24: struct with 184 pointer bytes could be 152
/Users/estensen/Developer/erigon-lib/state/merge.go:69:19: struct of size 72 could be 56
/Users/estensen/Developer/erigon-lib/state/merge.go:143:20: struct of size 48 could be 40
/Users/estensen/Developer/erigon-lib/state/read_indices.go:29:18: struct with 64 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/state/read_indices.go:211:14: struct of size 72 could be 56
/Users/estensen/Developer/erigon-lib/state/read_indices.go:233:27: struct with 72 pointer bytes could be 56
/Users/estensen/Developer/erigon-lib/state/state_recon.go:61:16: struct with 56 pointer bytes could be 16
/Users/estensen/Developer/erigon-lib/state/state_recon.go:112:19: struct with 136 pointer bytes could be 112
/Users/estensen/Developer/erigon-lib/state/state_recon.go:190:22: struct with 128 pointer bytes could be 112
/Users/estensen/Developer/erigon-lib/types/testdata.go:81:26: struct with 40 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/types/txn.go:46:21: struct with 400 pointer bytes could be 40
/Users/estensen/Developer/erigon-lib/types/txn.go:82:13: struct with 200 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/types/txn.go:691:18: struct with 32 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/txpool/fetch.go:43:12: struct with 136 pointer bytes could be 112
/Users/estensen/Developer/erigon-lib/txpool/pool.go:69:13: struct with 104 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/txpool/pool.go:221:13: struct of size 104 could be 96
/Users/estensen/Developer/erigon-lib/txpool/pool.go:291:13: struct with 336 pointer bytes could be 288
/Users/estensen/Developer/erigon-lib/txpool/pool.go:1789:29: struct with 32 pointer bytes could be 8
/Users/estensen/Developer/erigon-lib/txpool/pool.go:1819:19: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/erigon-lib/txpool/pool.go:1994:18: struct of size 64 could be 56
/Users/estensen/Developer/erigon-lib/txpool/pool.go:2102:14: struct of size 64 could be 56
/Users/estensen/Developer/erigon-lib/txpool/send.go:37:11: struct with 64 pointer bytes could be 48
/Users/estensen/Developer/erigon-lib/txpool/test_util.go:31:17: struct with 72 pointer bytes could be 40
```