### PR TITLE
txpool: prevent index out of range 2

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2055,7 +2055,9 @@ func (p *PendingPool) Worst() *metaTx { //nolint
 }
 func (p *PendingPool) PopWorst() *metaTx { //nolint
 	i := heap.Pop(p.worst).(*metaTx)
-	p.best.UnsafeRemove(i)
+	if i.bestIndex >= 0 {
+		p.best.UnsafeRemove(i)
+	}
 	return i
 }
 func (p *PendingPool) Updated(mt *metaTx) {


### PR DESCRIPTION
(Continuation of PR #690)

Fixes the following error reported by stickx:
![PXL_20221024_214752470](https://user-images.githubusercontent.com/34320705/197769120-65e01142-4948-4e04-a555-16675ef9d9f7.jpeg)
