### PR TITLE
Remove deprectated linter structcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-#    - structcheck # go1.18
     - unused
 #    - gocritic
     - bodyclose # go1.18


### PR DESCRIPTION
`WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.`