### PR TITLE
Makefile: fix for mac m1/2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ ARCH = $(shell uname -m)
 
 ifeq ($(OS),Darwin)
 PROTOC_OS := osx
+ifeq ($(ARCH),arm64)
+ARCH = aarch_64
+endif
 endif
 ifeq ($(OS),Linux)
 PROTOC_OS = linux


### PR DESCRIPTION
Arch name was producing 404 when downloading releases from github for protoc due to incorrect arch name.