### PR TITLE
fix(test): eliminate race conditions

### DIFF
--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -406,6 +406,8 @@ func (db *MdbxKV) Close() {
 	if db.closed.Load() {
 		return
 	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	db.closed.Store(true)
 	db.wg.Wait()
 	db.env.Close()
@@ -466,6 +468,9 @@ func (db *MdbxKV) BeginRw(_ context.Context) (txn kv.RwTx, err error) {
 	}
 	runtime.LockOSThread()
 	defer func() {
+		if db.closed.Load() {
+			return
+		}
 		if err == nil {
 			db.wg.Add(1)
 		}


### PR DESCRIPTION
Close and BeginRw clash during tests causing race condition, this eliminates the race. We need to ensure it is safe in runtime code.