### PR TITLE
txpool: honour nonce while sorting txs

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -2231,16 +2231,27 @@ func (mt *metaTx) better(than *metaTx, pendingBaseFee uint256.Int) bool {
 		if effectiveTip.Cmp(&thanEffectiveTip) != 0 {
 			return effectiveTip.Cmp(&thanEffectiveTip) > 0
 		}
+		// Only compare nonces and balances for same sender
+		if mt.Tx.SenderID == than.Tx.SenderID {
+			if mt.nonceDistance != than.nonceDistance {
+				return mt.nonceDistance > than.nonceDistance
+			}
+			if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
+				return mt.cumulativeBalanceDistance > than.cumulativeBalanceDistance
+			}
+		}
 	case BaseFeeSubPool:
 		if mt.minFeeCap.Cmp(&than.minFeeCap) != 0 {
 			return mt.minFeeCap.Cmp(&than.minFeeCap) > 0
 		}
 	case QueuedSubPool:
-		if mt.nonceDistance != than.nonceDistance {
-			return mt.nonceDistance < than.nonceDistance
-		}
-		if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
-			return mt.cumulativeBalanceDistance < than.cumulativeBalanceDistance
+		if mt.Tx.SenderID == than.Tx.SenderID {
+			if mt.nonceDistance != than.nonceDistance {
+				return mt.nonceDistance < than.nonceDistance
+			}
+			if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
+				return mt.cumulativeBalanceDistance < than.cumulativeBalanceDistance
+			}
 		}
 	}
 	return mt.timestamp < than.timestamp
@@ -2264,18 +2275,23 @@ func (mt *metaTx) worse(than *metaTx, pendingBaseFee uint256.Int) bool {
 		if mt.minFeeCap != than.minFeeCap {
 			return mt.minFeeCap.Cmp(&than.minFeeCap) < 0
 		}
-		if mt.nonceDistance != than.nonceDistance {
-			return mt.nonceDistance > than.nonceDistance
-		}
-		if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
-			return mt.cumulativeBalanceDistance > than.cumulativeBalanceDistance
+		// Only compare nonces and balances for same sender
+		if mt.Tx.SenderID == than.Tx.SenderID {
+			if mt.nonceDistance != than.nonceDistance {
+				return mt.nonceDistance > than.nonceDistance
+			}
+			if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
+				return mt.cumulativeBalanceDistance > than.cumulativeBalanceDistance
+			}
 		}
 	case BaseFeeSubPool, QueuedSubPool:
-		if mt.nonceDistance != than.nonceDistance {
-			return mt.nonceDistance > than.nonceDistance
-		}
-		if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
-			return mt.cumulativeBalanceDistance > than.cumulativeBalanceDistance
+		if mt.Tx.SenderID == than.Tx.SenderID {
+			if mt.nonceDistance != than.nonceDistance {
+				return mt.nonceDistance > than.nonceDistance
+			}
+			if mt.cumulativeBalanceDistance != than.cumulativeBalanceDistance {
+				return mt.cumulativeBalanceDistance > than.cumulativeBalanceDistance
+			}
 		}
 	}
 	return mt.timestamp > than.timestamp


### PR DESCRIPTION
In context of https://github.com/ledgerwatch/erigon/issues/5694, this PR fixes the tx ordering logic in the txpool. 

When the mining module used to query the best transactions, the response of transactions weren't sorted according to nonce (for same sender address). This caused the execution to fail (except 1). The txpool orders the transactions using this underlying `better()` and `worse()` functions. The `better()` function didn't have a nonce check for the pending pool, while the `worse()` function had. This PR adds a check which would compare and put a transaction with lower nonce ahead. 

Moreover, on further investigation, these checks were applied for all types of transactions. It only makes sense compare the nonce for transactions which has same sender account. Hence, this PR also adds an additional check along with.