### PR TITLE
txpool to consider available gas in Best call

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -34,6 +34,9 @@ import (
 	"github.com/google/btree"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/log/v3"
+	"go.uber.org/atomic"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/cmp"
@@ -47,8 +50,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/types"
-	"github.com/ledgerwatch/log/v3"
-	"go.uber.org/atomic"
 )
 
 var (
@@ -599,7 +600,7 @@ func (p *TxPool) Started() bool                      { return p.started.Load() }
 
 // Best - returns top `n` elements of pending queue
 // id doesn't perform full copy of txs, however underlying elements are immutable
-func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf uint64) (bool, error) {
+func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64) (bool, error) {
 	// First wait for the corresponding block to arrive
 	if p.lastSeenBlock.Load() < onTopOf {
 		return false, nil // Too early
@@ -615,6 +616,12 @@ func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf uint64) (bo
 
 		best := p.pending.best
 		for i := 0; j < int(n) && i < len(best.ms); i++ {
+
+			// if we wouldn't have enough gas for a standard transaction then quit out early
+			if availableGas < fixedgas.TxGas {
+				break
+			}
+
 			mt := best.ms[i]
 			if mt.Tx.Gas >= p.blockGasLimit.Load() {
 				// Skip transactions with very large gas limit
@@ -628,6 +635,17 @@ func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf uint64) (bo
 				toRemove = append(toRemove, mt)
 				continue
 			}
+
+			// make sure we have enough gas in the caller to add this transaction.
+			// not an exact science using intrinsic gas but as close as we could hope for at
+			// this stage
+			intrinsicGas, _ := CalcIntrinsicGas(uint64(mt.Tx.DataLen), uint64(mt.Tx.DataNonZeroLen), nil, mt.Tx.Creation, true, true)
+			if intrinsicGas > availableGas {
+				// we might find another TX with a low enough intrinsic gas to include so carry on
+				continue
+			}
+			availableGas -= intrinsicGas
+
 			txs.Txs[j] = rlpTx
 			copy(txs.Senders.At(j), sender)
 			txs.IsLocal[j] = isLocal


### PR DESCRIPTION
Take gas into consideration when calling `Best`, the idea being to run down the top transactions looking for those that won't overdo it on the gas front.  We won't know until actual execution but it gets us some of the way there.