### PR TITLE
Use hex package to convert bytes to string

### DIFF
--- a/etl/collector.go
+++ b/etl/collector.go
@@ -19,6 +19,7 @@ package etl
 import (
 	"bytes"
 	"container/heap"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -288,9 +289,9 @@ func makeCurrentKeyStr(k []byte) string {
 	if k == nil {
 		currentKeyStr = "final"
 	} else if len(k) < 4 {
-		currentKeyStr = fmt.Sprintf("%x", k)
+		currentKeyStr = hex.EncodeToString(k)
 	} else if k[0] == 0 && k[1] == 0 && k[2] == 0 && k[3] == 0 && len(k) >= 8 { // if key has leading zeroes, show a bit more info
-		currentKeyStr = fmt.Sprintf("%x", k)
+		currentKeyStr = hex.EncodeToString(k)
 	} else {
 		currentKeyStr = fmt.Sprintf("%x...", k[:4])
 	}

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -21,6 +21,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1461,7 +1462,7 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 				hashSentTo := send.AnnouncePooledTxs(localTxHashes)
 				for i := 0; i < localTxHashes.Len(); i++ {
 					hash := localTxHashes.At(i)
-					log.Info("local tx propagated", "tx_hash", fmt.Sprintf("%x", hash), "announced to peers", hashSentTo[i], "broadcast to peers", txSentTo[i], "baseFee", p.pendingBaseFee.Load())
+					log.Info("local tx propagated", "tx_hash", hex.EncodeToString(hash), "announced to peers", hashSentTo[i], "broadcast to peers", txSentTo[i], "baseFee", p.pendingBaseFee.Load())
 				}
 				send.BroadcastPooledTxs(remoteTxRlps)
 				send.AnnouncePooledTxs(remoteTxHashes)


### PR DESCRIPTION
From my [benchmarks](https://github.com/estensen/benchmarks/blob/master/encoding/encoding.go) it's a lot faster. Especially for few bytes.

```

cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkByteToHex/encode_bytes_to_hex_string_with_fmt.Sprintf_for_1_byte-12         	12689306	        89.64 ns/op	      26 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_hex.EncodeToString_for_1_byte-12  	80529291	        14.74 ns/op	       2 B/op	       1 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_fmt.Sprintf_for_5_bytes-12        	10836607	       108.2 ns/op	      40 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_hex.EncodeToString_for_5_bytes-12 	42891154	        28.82 ns/op	      16 B/op	       1 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_fmt.Sprintf_for_10_bytes-12       	 9706875	       119.8 ns/op	      48 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_hex.EncodeToString_for_10_bytes-12         	31689613	        33.88 ns/op	      24 B/op	       1 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_fmt.Sprintf_for_50_bytes-12                	 5202006	       210.4 ns/op	     136 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_hex.EncodeToString_for_50_bytes-12         	10616301	       109.5 ns/op	     224 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_fmt.Sprintf_for_100_bytes-12               	 5614594	       210.9 ns/op	     136 B/op	       2 allocs/op
BenchmarkByteToHex/encode_bytes_to_hex_string_with_hex.EncodeToString_for_100_bytes-12        	10426776	       108.6 ns/op	     224 B/op	       2 allocs/op
```