### PR TITLE
txpool to mark candidate txs for mining

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -230,6 +230,7 @@ type metaTx struct {
 	timestamp                 uint64 // when it was added to pool
 	subPool                   SubPoolMarker
 	currentSubPool            SubPoolType
+	candidate                 bool
 }
 
 func newMetaTx(slot *types.TxSlot, isLocal bool, timestmap uint64) *metaTx {
@@ -602,7 +603,7 @@ func (p *TxPool) Started() bool                      { return p.started.Load() }
 
 // Best - returns top `n` elements of pending queue
 // id doesn't perform full copy of txs, however underlying elements are immutable
-func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64) (bool, error) {
+func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64, isMining bool) (bool, error) {
 	// First wait for the corresponding block to arrive
 	if p.lastSeenBlock.Load() < onTopOf {
 		return false, nil // Too early
@@ -618,13 +619,17 @@ func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 
 		best := p.pending.best
 		for i := 0; j < int(n) && i < len(best.ms); i++ {
-
 			// if we wouldn't have enough gas for a standard transaction then quit out early
 			if availableGas < fixedgas.TxGas {
 				break
 			}
 
 			mt := best.ms[i]
+
+			if isMining && mt.candidate {
+				continue
+			}
+
 			if mt.Tx.Gas >= p.blockGasLimit.Load() {
 				// Skip transactions with very large gas limit
 				continue
@@ -654,6 +659,9 @@ func (p *TxPool) Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 			txs.Txs[j] = rlpTx
 			copy(txs.Senders.At(j), sender)
 			txs.IsLocal[j] = isLocal
+			if isMining {
+				mt.candidate = true
+			}
 			j++
 		}
 		return true, nil

--- a/txpool/txpool_grpc_server.go
+++ b/txpool/txpool_grpc_server.go
@@ -51,7 +51,7 @@ var TxPoolAPIVersion = &types2.VersionReply{Major: 1, Minor: 0, Patch: 0}
 type txPool interface {
 	ValidateSerializedTxn(serializedTxn []byte) error
 
-	Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64) (bool, error)
+	Best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64, isMining bool) (bool, error)
 	GetRlp(tx kv.Tx, hash []byte) ([]byte, error)
 	AddLocalTxs(ctx context.Context, newTxs types.TxSlots, tx kv.Tx) ([]DiscardReason, error)
 	deprecatedForEach(_ context.Context, f func(rlp, sender []byte, t SubPoolType), tx kv.Tx)
@@ -155,7 +155,7 @@ func (s *GrpcServer) Pending(ctx context.Context, _ *emptypb.Empty) (*txpool_pro
 	reply := &txpool_proto.PendingReply{}
 	reply.Txs = make([]*txpool_proto.PendingReply_Tx, 0, 32)
 	txSlots := types.TxsRlp{}
-	if _, err := s.txPool.Best(math.MaxInt16, &txSlots, tx, 0 /* onTopOf */, math.MaxUint64 /* available gas */); err != nil {
+	if _, err := s.txPool.Best(math.MaxInt16, &txSlots, tx, 0 /* onTopOf */, math.MaxUint64 /* available gas */, false); err != nil {
 		return nil, err
 	}
 	var senderArr [20]byte


### PR DESCRIPTION
as we're now visiting the txpool multiple times during mining we need a way to ensure we're not trying to include the same transactions twice and to only get new data each time.  This seems a simple way to achieve this, but if there would be a better way let me know.