### PR TITLE
nit: tweak error handling for rlp too big

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -822,7 +822,7 @@ func (p *TxPool) ValidateSerializedTxn(serializedTxn []byte) error {
 		txMaxSize = 4 * txSlotSize // 128KB
 	)
 	if len(serializedTxn) > txMaxSize {
-		return types.RlpTooBig
+		return types.ErrRlpTooBig
 	}
 	return nil
 }

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -778,7 +778,7 @@ func (p *TxPool) ValidateSerializedTxn(serializedTxn []byte) error {
 		txMaxSize = 4 * txSlotSize // 128KB
 	)
 	if len(serializedTxn) > txMaxSize {
-		return fmt.Errorf(RLPTooLong.String())
+		return types.RlpTooBig
 	}
 	return nil
 }

--- a/txpool/txpool_grpc_server.go
+++ b/txpool/txpool_grpc_server.go
@@ -240,7 +240,7 @@ func mapDiscardReasonToProto(reason DiscardReason) txpool_proto.ImportResult {
 		return txpool_proto.ImportResult_ALREADY_EXISTS
 	case UnderPriced, ReplaceUnderpriced, FeeTooLow:
 		return txpool_proto.ImportResult_FEE_TOO_LOW
-	case InvalidSender, NegativeValue, OversizedData, InitCodeTooLarge, RlpTooLong:
+	case InvalidSender, NegativeValue, OversizedData, InitCodeTooLarge, RLPTooLong:
 		return txpool_proto.ImportResult_INVALID
 	default:
 		return txpool_proto.ImportResult_INTERNAL_ERROR

--- a/txpool/txpool_grpc_server.go
+++ b/txpool/txpool_grpc_server.go
@@ -240,7 +240,7 @@ func mapDiscardReasonToProto(reason DiscardReason) txpool_proto.ImportResult {
 		return txpool_proto.ImportResult_ALREADY_EXISTS
 	case UnderPriced, ReplaceUnderpriced, FeeTooLow:
 		return txpool_proto.ImportResult_FEE_TOO_LOW
-	case InvalidSender, NegativeValue, OversizedData:
+	case InvalidSender, NegativeValue, OversizedData, RlpTooLong:
 		return txpool_proto.ImportResult_INVALID
 	default:
 		return txpool_proto.ImportResult_INTERNAL_ERROR


### PR DESCRIPTION
I believe ValidateSerializedTxn should be returning (or at least wrapping) types.RlpTooBig instead of creating a new error when the transaction exceeds max size, since this is the error the txpool actually checks for:

https://github.com/ledgerwatch/erigon-lib/blob/61706714c391a85922d0486ec8bf8c49385fc029/txpool/txpool_grpc_server.go#L204

Before this change the ImportResult for an oversized tx would be INTERNAL_ERROR; after this change it will be INVALID, which seems more appropriate.
