### PR TITLE
Rollback MDBX upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ledgerwatch/log/v3 v3.7.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/ledgerwatch/trackerslist v1.0.0
-	github.com/torquem-ch/mdbx-go v0.28.1
+	github.com/torquem-ch/mdbx-go v0.27.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/tidwall/btree v1.5.0/go.mod h1:LGm8L/DZjPLmeWGjv5kFrY8dL4uVhMmzmmLYms
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
-github.com/torquem-ch/mdbx-go v0.28.1 h1:MxoEuK0tidGrWAdjlAjv79iAo1OyMpy1WBPnyiST6cU=
-github.com/torquem-ch/mdbx-go v0.28.1/go.mod h1:T2fsoJDVppxfAPTLd1svUgH1kpPmeXdPESmroSHcL1E=
+github.com/torquem-ch/mdbx-go v0.27.5 h1:bbhXQGFCmoxbRDXKYEJwxSOOTeBKwoD4pFBUpK9+V1g=
+github.com/torquem-ch/mdbx-go v0.27.5/go.mod h1:T2fsoJDVppxfAPTLd1svUgH1kpPmeXdPESmroSHcL1E=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -583,11 +583,6 @@ func (tx *MdbxTx) CollectMetrics() {
 	kv.DbPgopsSpill.Set(info.PageOps.Spill)
 	kv.DbPgopsUnspill.Set(info.PageOps.Unspill)
 	kv.DbPgopsWops.Set(info.PageOps.Wops)
-	kv.DbPgopsPrefault.Set(info.PageOps.Prefault)
-	kv.DbPgopsMinicore.Set(info.PageOps.Minicore)
-	kv.DbPgopsMsync.Set(info.PageOps.Msync)
-	kv.DbPgopsFsync.Set(info.PageOps.Fsync)
-	kv.DbMiLastPgNo.Set(info.MiLastPgNo * tx.db.opts.pageSize)
 
 	txInfo, err := tx.tx.Info(true)
 	if err != nil {
@@ -794,33 +789,11 @@ func (tx *MdbxTx) Commit() error {
 
 	if tx.db.opts.label == kv.ChainDB {
 		kv.DbCommitPreparation.Update(latency.Preparation.Seconds())
-		kv.DbGCWallClock.Update(latency.GCWallClock.Seconds())
-		kv.DbGCCpuTime.Update(latency.GCCpuTime.Seconds())
 		kv.DbCommitAudit.Update(latency.Audit.Seconds())
 		kv.DbCommitWrite.Update(latency.Write.Seconds())
 		kv.DbCommitSync.Update(latency.Sync.Seconds())
 		kv.DbCommitEnding.Update(latency.Ending.Seconds())
 		kv.DbCommitTotal.Update(latency.Whole.Seconds())
-
-		kv.DbGcWorkRtime.Update(latency.GCDetails.WorkRtime.Seconds())
-		kv.DbGcSelfRtime.Update(latency.GCDetails.SelfRtime.Seconds())
-		kv.DbGcSelfXtime.Update(latency.GCDetails.SelfXtime.Seconds())
-		kv.DbGcWorkXtime.Update(latency.GCDetails.WorkXtime.Seconds())
-
-		kv.DbGcWorkRsteps.Set(uint64(latency.GCDetails.WorkRsteps))
-		kv.DbGcSelfRsteps.Set(uint64(latency.GCDetails.SelfRsteps))
-
-		kv.DbGcWorkRxpages.Set(uint64(latency.GCDetails.WorkRxpages))
-		kv.DbGcSelfXpages.Set(uint64(latency.GCDetails.SelfXpages))
-		kv.DbGcWloops.Set(uint64(latency.GCDetails.Wloops))
-		kv.DbGcCoalescences.Set(uint64(latency.GCDetails.Coalescences))
-		kv.DbGcWipes.Set(uint64(latency.GCDetails.Wipes))
-		kv.DbGcFlushes.Set(uint64(latency.GCDetails.Flushes))
-		kv.DbGcKicks.Set(uint64(latency.GCDetails.Kicks))
-		kv.DbGcWorkMajflt.Set(uint64(latency.GCDetails.WorkMajflt))
-		kv.DbGcSelfMajflt.Set(uint64(latency.GCDetails.SelfMajflt))
-		kv.DbGcWorkCounter.Set(uint64(latency.GCDetails.WorkCounter))
-		kv.DbGcSelfCounter.Set(uint64(latency.GCDetails.SelfCounter))
 
 		//kv.DbGcWorkPnlMergeTime.Update(latency.GCDetails.WorkPnlMergeTime.Seconds())
 		//kv.DbGcWorkPnlMergeVolume.Set(uint64(latency.GCDetails.WorkPnlMergeVolume))

--- a/kv/memdb/memory_mutation_test.go
+++ b/kv/memdb/memory_mutation_test.go
@@ -36,10 +36,10 @@ func TestPutAppendHas(t *testing.T) {
 
 	batch := NewMemoryBatch(rwTx, "")
 	require.NoError(t, batch.Append(kv.HashedAccounts, []byte("AAAA"), []byte("value1.5")))
-	require.NoError(t, batch.Append(kv.HashedAccounts, []byte("AAAA"), []byte("value1.3")))
+	require.Error(t, batch.Append(kv.HashedAccounts, []byte("AAAA"), []byte("value1.3")))
 	require.NoError(t, batch.Put(kv.HashedAccounts, []byte("AAAA"), []byte("value1.3")))
 	require.NoError(t, batch.Append(kv.HashedAccounts, []byte("CBAA"), []byte("value3.5")))
-	require.NoError(t, batch.Append(kv.HashedAccounts, []byte("CBAA"), []byte("value3.1")))
+	require.Error(t, batch.Append(kv.HashedAccounts, []byte("CBAA"), []byte("value3.1")))
 	require.NoError(t, batch.AppendDup(kv.HashedAccounts, []byte("CBAA"), []byte("value3.1")))
 	require.Error(t, batch.Append(kv.HashedAccounts, []byte("AAAA"), []byte("value1.3")))
 


### PR DESCRIPTION
There is some circumstantial evidence that there are some regressions in this version of MDBX, I would like to rollback to either remove these regressions or at least eliminate one of the possible causes