### PR TITLE
Fix copylock when use sync.Pool in bitmapdb.go

### DIFF
--- a/kv/bitmapdb/bitmapdb.go
+++ b/kv/bitmapdb/bitmapdb.go
@@ -54,7 +54,7 @@ func ReturnToPool(a *roaring.Bitmap) {
 	roaringPool.Put(a)
 }
 
-var roaring64Pool = sync.Pool{
+var roaring64Pool = &sync.Pool{
 	New: func() any {
 		return roaring64.New()
 	},

--- a/kv/bitmapdb/bitmapdb.go
+++ b/kv/bitmapdb/bitmapdb.go
@@ -36,7 +36,7 @@ type ToBitamp interface {
 	ToBitmap() (*roaring64.Bitmap, error)
 }
 
-var roaringPool = sync.Pool{
+var roaringPool = &sync.Pool{
 	New: func() any {
 		return roaring.New()
 	},


### PR DESCRIPTION
according to sync.Pool doc:
[sync.Pool](https://pkg.go.dev/sync#Pool)

```shell
A Pool must not be copied after first use
```

That is because sync.Pool contains noCopy. So to avoid copied after use, maybe a *sync.Pool is better?