### PR TITLE
Fix index out of range in TxPool.best

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -612,15 +612,17 @@ func (p *TxPool) IsLocal(idHash []byte) bool {
 func (p *TxPool) AddNewGoodPeer(peerID types.PeerID) { p.recentlyConnectedPeers.AddPeer(peerID) }
 func (p *TxPool) Started() bool                      { return p.started.Load() }
 
-func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
+func (p *TxPool) best(n uint, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
 	// First wait for the corresponding block to arrive
 	if p.lastSeenBlock.Load() < onTopOf {
 		return false, 0, nil // Too early
 	}
 
 	isShanghai := p.isShanghai()
+	best := p.pending.best
 
-	txs.Resize(uint(cmp.Min(int(n), len(p.pending.best.ms))))
+	n = uint(cmp.Min(int(n), len(best.ms)))
+	txs.Resize(n)
 	var toRemove []*metaTx
 	count := 0
 
@@ -628,7 +630,6 @@ func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableG
 		p.lock.Lock()
 		defer p.lock.Unlock()
 
-		best := p.pending.best
 		for i := 0; count < int(n) && i < len(best.ms); i++ {
 			// if we wouldn't have enough gas for a standard transaction then quit out early
 			if availableGas < fixedgas.TxGas {
@@ -696,12 +697,12 @@ func (p *TxPool) ResetYieldedStatus() {
 }
 
 func (p *TxPool) YieldBest(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
-	return p.best(n, txs, tx, onTopOf, availableGas, toSkip)
+	return p.best(uint(n), txs, tx, onTopOf, availableGas, toSkip)
 }
 
 func (p *TxPool) PeekBest(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas uint64) (bool, error) {
 	set := mapset.NewSet[[32]byte]()
-	onTime, _, err := p.best(n, txs, tx, onTopOf, availableGas, set)
+	onTime, _, err := p.best(uint(n), txs, tx, onTopOf, availableGas, set)
 	return onTime, err
 }
 


### PR DESCRIPTION
This should fix
```
CLMocker: Could not getPayload (a55589c9, 0x0000000000000003): runtime error: index out of range [15] with length 15, trace: [stageloop.go:262 panic.go:884 panic.go:113 pool.go:670 pool.go:677 pool.go:699 stage_mining_exec.go:204 kv_mdbx.go:622 stage_mining_exec.go:199 stage_mining_exec.go:135 stagebuilder.go:41 sync.go:353 sync.go:255 stageloop.go:275 backend.go:518 block_builder.go:30 asm_amd64.s:1594]
```
which I occasionally observed in my Hive test runs.