### PR TITLE
Downloader: "incomplete" markers are more important than "complete", so commit them with fsync 

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -430,8 +430,6 @@ func MainLoop(ctx context.Context, d *Downloader, silent bool) {
 					log.Info("[Snapshots] Stats", "banned", ips)
 				}
 			}
-
-			_ = d.db.Update(ctx, func(tx kv.RwTx) error { return nil })
 		}
 	}
 }

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -76,6 +76,7 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 	// On power-off recent "no-sync" txs may be lost. It will cause 2. cases:
 	//  - Good piece on disk and recent "complete" db marker lost. Self-Heal by re-download.
 	//  - Bad piece on dis and recent "incomplete" db marker lost. No Self-Heal. So, can't afford loosing recent "incomplete" markers.
+	// FYI: Fsync of torrent pieces happenng before storing db markers: https://github.com/anacrolix/torrent/blob/master/torrent.go#L2026
 	if b {
 		tx, err = m.db.BeginRwNosync(m.ctx)
 		if err != nil {

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -82,6 +82,11 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 	//  - Good piece on disk and recent "complete"   db marker lost. Self-Heal by re-download.
 	//  - Bad  piece on disk and recent "incomplete" db marker lost. No Self-Heal. Means: can't afford loosing recent "incomplete" markers.
 	// FYI: Fsync of torrent pieces happenng before storing db markers: https://github.com/anacrolix/torrent/blob/master/torrent.go#L2026
+	//
+	// Mainnet stats:
+	//  call amount 2 minutes complete=100K vs incomple=1K
+	//  1K fsyncs/2minutes it's quite expensive, but even on cloud (high latency) drive it allow download 100mb/s
+	//  and node doesn't do anything when downloading snapshots
 	if b {
 		res := in.Inc()
 		if res%1000 == 0 {

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -83,14 +83,17 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 	//  - Bad  piece on disk and recent "incomplete" db marker lost. No Self-Heal. Means: can't afford loosing recent "incomplete" markers.
 	// FYI: Fsync of torrent pieces happenng before storing db markers: https://github.com/anacrolix/torrent/blob/master/torrent.go#L2026
 	if b {
-		in.Inc()
+		res := in.Inc()
+		if res%100 == 0 {
+			log.Warn("stat", "complete", c.Load(), "incomplete", in.Load())
+		}
 		tx, err = m.db.BeginRwNosync(m.ctx)
 		if err != nil {
 			return err
 		}
 	} else {
 		res := c.Inc()
-		if res%10 == 0 {
+		if res%100 == 0 {
 			log.Warn("stat", "complete", c.Load(), "incomplete", in.Load())
 		}
 

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -86,7 +86,7 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 	// Mainnet stats:
 	//  call amount 2 minutes complete=100K vs incomple=1K
 	//  1K fsyncs/2minutes it's quite expensive, but even on cloud (high latency) drive it allow download 100mb/s
-	//  and node doesn't do anything when downloading snapshots
+	//  and Erigon doesn't do anything when downloading snapshots
 	if b {
 		res := in.Inc()
 		if res%1000 == 0 {

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
+	"github.com/anacrolix/torrent/types/infohash"
 	"github.com/ledgerwatch/erigon-lib/kv"
 )
 
@@ -31,22 +32,24 @@ const (
 )
 
 type mdbxPieceCompletion struct {
-	db kv.RwDB
+	db  kv.RwDB
+	ctx context.Context
 }
 
 var _ storage.PieceCompletion = (*mdbxPieceCompletion)(nil)
 
-func NewMdbxPieceCompletion(db kv.RwDB) (ret storage.PieceCompletion, err error) {
-	ret = &mdbxPieceCompletion{db}
+func NewMdbxPieceCompletion(ctx context.Context, db kv.RwDB) (ret storage.PieceCompletion, err error) {
+	ret = &mdbxPieceCompletion{ctx: ctx, db: db}
 	return
 }
 
-func (me mdbxPieceCompletion) Get(pk metainfo.PieceKey) (cn storage.Completion, err error) {
-	err = me.db.View(context.Background(), func(tx kv.Tx) error {
-		var key [4]byte
-		binary.BigEndian.PutUint32(key[:], uint32(pk.Index))
+func (m mdbxPieceCompletion) Get(pk metainfo.PieceKey) (cn storage.Completion, err error) {
+	err = m.db.View(m.ctx, func(tx kv.Tx) error {
+		var key [infohash.Size + 4]byte
+		copy(key[:], pk.InfoHash[:])
+		binary.BigEndian.PutUint32(key[infohash.Size:], uint32(pk.Index))
 		cn.Ok = true
-		v, err := tx.GetOne(kv.BittorrentCompletion, append(pk.InfoHash[:], key[:]...))
+		v, err := tx.GetOne(kv.BittorrentCompletion, key[:])
 		if err != nil {
 			return err
 		}
@@ -63,27 +66,46 @@ func (me mdbxPieceCompletion) Get(pk metainfo.PieceKey) (cn storage.Completion, 
 	return
 }
 
-func (me mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
-	if c, err := me.Get(pk); err == nil && c.Ok && c.Complete == b {
+func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
+	if c, err := m.Get(pk); err == nil && c.Ok && c.Complete == b {
 		return nil
 	}
-	return me.db.Update(context.Background(), func(tx kv.RwTx) error {
-		var key [4]byte
-		binary.BigEndian.PutUint32(key[:], uint32(pk.Index))
 
-		v := []byte(incomplete)
-		if b {
-			v = []byte(complete)
-		}
-		err := tx.Put(kv.BittorrentCompletion, append(pk.InfoHash[:], key[:]...), v)
+	var tx kv.RwTx
+	var err error
+	// On power-off recent "no-sync" txs may be lost. It will cause 2. cases:
+	//  - Good piece on disk and recent "complete" db marker lost. Self-Heal by re-download.
+	//  - Bad piece on dis and recent "incomplete" db marker lost. No Self-Heal. So, can't afford loosing recent "incomplete" markers.
+	if b {
+		tx, err = m.db.BeginRwNosync(m.ctx)
 		if err != nil {
 			return err
 		}
-		return nil
-	})
+	} else {
+		tx, err = m.db.BeginRw(m.ctx)
+		if err != nil {
+			return err
+		}
+	}
+	defer tx.Rollback()
+
+	var key [infohash.Size + 4]byte
+	copy(key[:], pk.InfoHash[:])
+	binary.BigEndian.PutUint32(key[infohash.Size:], uint32(pk.Index))
+
+	v := []byte(incomplete)
+	if b {
+		v = []byte(complete)
+	}
+	err = tx.Put(kv.BittorrentCompletion, key[:], v)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
-func (me *mdbxPieceCompletion) Close() error {
-	me.db.Close()
+func (m *mdbxPieceCompletion) Close() error {
+	m.db.Close()
 	return nil
 }

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -24,6 +24,7 @@ import (
 	"github.com/anacrolix/torrent/storage"
 	"github.com/anacrolix/torrent/types/infohash"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
 )
 
 const (
@@ -84,6 +85,8 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 			return err
 		}
 	} else {
+		log.Warn("incomplete")
+
 		tx, err = m.db.BeginRw(m.ctx)
 		if err != nil {
 			return err

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -84,7 +84,7 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 	// FYI: Fsync of torrent pieces happenng before storing db markers: https://github.com/anacrolix/torrent/blob/master/torrent.go#L2026
 	if b {
 		res := in.Inc()
-		if res%100 == 0 {
+		if res%1000 == 0 {
 			log.Warn("stat", "complete", c.Load(), "incomplete", in.Load())
 		}
 		tx, err = m.db.BeginRwNosync(m.ctx)

--- a/downloader/mdbx_piece_completion.go
+++ b/downloader/mdbx_piece_completion.go
@@ -24,7 +24,6 @@ import (
 	"github.com/anacrolix/torrent/storage"
 	"github.com/anacrolix/torrent/types/infohash"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/log/v3"
 )
 
 const (
@@ -85,7 +84,6 @@ func (m mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool) error {
 			return err
 		}
 	} else {
-		log.Warn("incomplete")
 		tx, err = m.db.BeginRw(m.ctx)
 		if err != nil {
 			return err

--- a/downloader/mdbx_piece_completion_test.go
+++ b/downloader/mdbx_piece_completion_test.go
@@ -17,6 +17,7 @@
 package downloader
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
@@ -29,7 +30,7 @@ import (
 
 func TestMdbxPieceCompletion(t *testing.T) {
 	db := memdb.NewTestDownloaderDB(t)
-	pc, err := NewMdbxPieceCompletion(db)
+	pc, err := NewMdbxPieceCompletion(context.Background(), db)
 	require.NoError(t, err)
 	defer pc.Close()
 

--- a/kv/kv_interface.go
+++ b/kv/kv_interface.go
@@ -238,10 +238,10 @@ type RwDB interface {
 	RoDB
 
 	Update(ctx context.Context, f func(tx RwTx) error) error
-	UpdateAsync(ctx context.Context, f func(tx RwTx) error) error
+	UpdateNosync(ctx context.Context, f func(tx RwTx) error) error
 
 	BeginRw(ctx context.Context) (RwTx, error)
-	BeginRwAsync(ctx context.Context) (RwTx, error)
+	BeginRwNosync(ctx context.Context) (RwTx, error)
 }
 
 type StatelessReadTx interface {

--- a/kv/kv_interface.go
+++ b/kv/kv_interface.go
@@ -361,7 +361,6 @@ type RwTx interface {
 	// CollectMetrics - does collect all DB-related and Tx-related metrics
 	// this method exists only in RwTx to avoid concurrency
 	CollectMetrics()
-	Reset() error
 }
 
 // BucketMigrator used for buckets migration, don't use it in usual app code

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -614,9 +614,6 @@ func (tx *MdbxTx) ListBuckets() ([]string, error) {
 }
 
 func (db *MdbxKV) View(ctx context.Context, f func(tx kv.Tx) error) (err error) {
-	if db.closed.Load() {
-		return fmt.Errorf("db closed")
-	}
 	// can't use db.evn.View method - because it calls commit for read transactions - it conflicts with write transactions.
 	tx, err := db.BeginRo(ctx)
 	if err != nil {
@@ -628,10 +625,6 @@ func (db *MdbxKV) View(ctx context.Context, f func(tx kv.Tx) error) (err error) 
 }
 
 func (db *MdbxKV) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
-	if db.closed.Load() {
-		return fmt.Errorf("db closed")
-	}
-
 	tx, err := db.BeginRwNosync(ctx)
 	if err != nil {
 		return err
@@ -649,10 +642,6 @@ func (db *MdbxKV) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (e
 }
 
 func (db *MdbxKV) Update(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
-	if db.closed.Load() {
-		return fmt.Errorf("db closed")
-	}
-
 	tx, err := db.BeginRw(ctx)
 	if err != nil {
 		return err
@@ -1016,27 +1005,6 @@ func (tx *MdbxTx) DBSize() (uint64, error) {
 		return 0, err
 	}
 	return info.Geo.Current, err
-}
-
-func (tx *MdbxTx) Reset() (err error) {
-	tx.Rollback()
-	//tx.printDebugInfo()
-	if tx.db.closed.Load() {
-		return fmt.Errorf("db closed")
-	}
-	runtime.LockOSThread()
-	defer func() {
-		if err == nil {
-			tx.db.wg.Add(1)
-		}
-	}()
-
-	tx.tx, err = tx.db.env.BeginTxn(nil, 0)
-	if err != nil {
-		runtime.UnlockOSThread() // unlock only in case of error. normal flow is "defer .Rollback()"
-		return fmt.Errorf("%w, lable: %s, trace: %s", err, tx.db.opts.label.String(), stack2.Trace().String())
-	}
-	return nil
 }
 
 func (tx *MdbxTx) RwCursor(bucket string) (kv.RwCursor, error) {

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -448,8 +448,10 @@ func (db *MdbxKV) Close() {
 }
 
 func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
-	if ctx.Err() != nil {
+	select {
+	case <-ctx.Done():
 		return nil, ctx.Err()
+	default:
 	}
 
 	if db.closed.Load() {
@@ -501,9 +503,12 @@ func (db *MdbxKV) BeginRwNosync(ctx context.Context) (kv.RwTx, error) {
 }
 
 func (db *MdbxKV) beginRw(ctx context.Context, flags uint) (txn kv.RwTx, err error) {
-	if ctx.Err() != nil {
+	select {
+	case <-ctx.Done():
 		return nil, ctx.Err()
+	default:
 	}
+
 	if db.closed.Load() {
 		return nil, fmt.Errorf("db closed")
 	}

--- a/kv/mdbx/kv_mdbx.go
+++ b/kv/mdbx/kv_mdbx.go
@@ -448,20 +448,13 @@ func (db *MdbxKV) Close() {
 }
 
 func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
 	if db.closed.Load() {
 		return nil, fmt.Errorf("db closed")
 	}
 
 	// don't try to acquire if the context is already done
-	done := ctx.Done()
 	select {
-	case <-done:
+	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
 		// otherwise carry on

--- a/kv/mdbx/kv_mdbx_temporary.go
+++ b/kv/mdbx/kv_mdbx_temporary.go
@@ -51,15 +51,15 @@ func (t *TemporaryMdbx) Update(ctx context.Context, f func(kv.RwTx) error) error
 	return t.db.Update(ctx, f)
 }
 
-func (t *TemporaryMdbx) UpdateAsync(ctx context.Context, f func(kv.RwTx) error) error {
-	return t.db.UpdateAsync(ctx, f)
+func (t *TemporaryMdbx) UpdateNosync(ctx context.Context, f func(kv.RwTx) error) error {
+	return t.db.UpdateNosync(ctx, f)
 }
 
 func (t *TemporaryMdbx) BeginRw(ctx context.Context) (kv.RwTx, error) {
 	return t.db.BeginRw(ctx)
 }
-func (t *TemporaryMdbx) BeginRwAsync(ctx context.Context) (kv.RwTx, error) {
-	return t.db.BeginRwAsync(ctx)
+func (t *TemporaryMdbx) BeginRwNosync(ctx context.Context) (kv.RwTx, error) {
+	return t.db.BeginRwNosync(ctx)
 }
 
 func (t *TemporaryMdbx) View(ctx context.Context, f func(kv.Tx) error) error {

--- a/kv/memdb/memory_mutation.go
+++ b/kv/memdb/memory_mutation.go
@@ -416,7 +416,3 @@ func (m *MemoryMutation) Cursor(bucket string) (kv.Cursor, error) {
 func (m *MemoryMutation) ViewID() uint64 {
 	panic("ViewID Not implemented")
 }
-
-func (m *MemoryMutation) Reset() error {
-	panic("MemoryMutation.Reset not implemented")
-}

--- a/kv/remotedb/kv_remote.go
+++ b/kv/remotedb/kv_remote.go
@@ -181,7 +181,7 @@ func (db *RemoteKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 func (db *RemoteKV) BeginRw(ctx context.Context) (kv.RwTx, error) {
 	return nil, fmt.Errorf("remote db provider doesn't support .BeginRw method")
 }
-func (db *RemoteKV) BeginRwAsync(ctx context.Context) (kv.RwTx, error) {
+func (db *RemoteKV) BeginRwNosync(ctx context.Context) (kv.RwTx, error) {
 	return nil, fmt.Errorf("remote db provider doesn't support .BeginRw method")
 }
 
@@ -198,7 +198,7 @@ func (db *RemoteKV) View(ctx context.Context, f func(tx kv.Tx) error) (err error
 func (db *RemoteKV) Update(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
 	return fmt.Errorf("remote db provider doesn't support .Update method")
 }
-func (db *RemoteKV) UpdateAsync(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
+func (db *RemoteKV) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
 	return fmt.Errorf("remote db provider doesn't support .Update method")
 }
 

--- a/state/aggregator_test.go
+++ b/state/aggregator_test.go
@@ -37,7 +37,7 @@ func testDbAndAggregator(t *testing.T, prefixLen int, aggStep uint64) (string, k
 func TestAggregator_Merge(t *testing.T) {
 	_, db, agg := testDbAndAggregator(t, 0, 100)
 
-	tx, err := db.BeginRwAsync(context.Background())
+	tx, err := db.BeginRwNosync(context.Background())
 	require.NoError(t, err)
 	defer func() {
 		if tx != nil {

--- a/state/history_test.go
+++ b/state/history_test.go
@@ -342,7 +342,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	ctx := context.Background()
-	tx, err := db.BeginRwAsync(ctx)
+	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(err)
 	h.SetTx(tx)
 	defer tx.Rollback()


### PR DESCRIPTION
 On power-off recent "no-sync" txs may be lost. It will cause 2. cases:
  - Good piece on disk and recent "complete" db marker lost. Self-Heal by re-download.
  - Bad piece on dis and recent "incomplete" db marker lost. No Self-Heal. So, can't afford loosing recent "incomplete" markers.
