### PR TITLE
PosdaoBlock is no longer needed

### DIFF
--- a/chain/chain_config.go
+++ b/chain/chain_config.go
@@ -67,9 +67,6 @@ type Config struct {
 	CancunTime   *big.Int `json:"cancunTime,omitempty"`
 	PragueTime   *big.Int `json:"pragueTime,omitempty"`
 
-	// Forks specific to Gnosis Chain
-	PosdaoBlock *big.Int `json:"posdaoBlock,omitempty"`
-
 	Eip1559FeeCollector           *common.Address `json:"eip1559FeeCollector,omitempty"`           // (Optional) Address where burnt EIP-1559 fees go to
 	Eip1559FeeCollectorTransition *big.Int        `json:"eip1559FeeCollectorTransition,omitempty"` // (Optional) Block from which burnt EIP-1559 fees go to the Eip1559FeeCollector
 


### PR DESCRIPTION
`PosdaoBlock` is no longer necessary after https://github.com/ledgerwatch/erigon/pull/7312