### PR TITLE
Update go-kzg-4844 to v0.3.0

### DIFF
--- a/crypto/kzg/kzg.go
+++ b/crypto/kzg/kzg.go
@@ -33,9 +33,9 @@ func InitializeCryptoCtx() {
 // Ctx returns a context object that stores all of the necessary configurations to allow one to
 // create and verify blob proofs.  This function is expensive to run if the crypto context isn't
 // initialized, so production services should pre-initialize by calling InitializeCryptoCtx.
-func Ctx() gokzg4844.Context {
+func Ctx() *gokzg4844.Context {
 	InitializeCryptoCtx()
-	return gCryptoCtx
+	return &gCryptoCtx
 }
 
 // KZGToVersionedHash implements kzg_to_versioned_hash from EIP-4844

--- a/crypto/kzg/kzg.go
+++ b/crypto/kzg/kzg.go
@@ -14,19 +14,19 @@ const (
 
 type VersionedHash [32]byte
 
-var gCryptoCtx gokzg4844.Context
+var gCryptoCtx *gokzg4844.Context
 var initCryptoCtx sync.Once
 
 // InitializeCryptoCtx initializes the global context object returned via CryptoCtx
 func InitializeCryptoCtx() {
 	initCryptoCtx.Do(func() {
+		var err error
 		// Initialize context to match the configurations that the
 		// specs are using.
-		ctx, err := gokzg4844.NewContext4096Insecure1337()
+		gCryptoCtx, err = gokzg4844.NewContext4096Insecure1337()
 		if err != nil {
 			panic(fmt.Sprintf("could not create context, err : %v", err))
 		}
-		gCryptoCtx = *ctx
 	})
 }
 
@@ -35,7 +35,7 @@ func InitializeCryptoCtx() {
 // initialized, so production services should pre-initialize by calling InitializeCryptoCtx.
 func Ctx() *gokzg4844.Context {
 	InitializeCryptoCtx()
-	return &gCryptoCtx
+	return gCryptoCtx
 }
 
 // KZGToVersionedHash implements kzg_to_versioned_hash from EIP-4844

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/anacrolix/log v0.14.0
 	github.com/anacrolix/torrent v1.52.0
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
-	github.com/crate-crypto/go-kzg-4844 v0.2.0
+	github.com/crate-crypto/go-kzg-4844 v0.3.0
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/go-stack/stack v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.10.0 h1:zRh22SR7o4K35SoNqouS9J/TKHTyU2QWaj5ldehyXtA=
 github.com/consensys/gnark-crypto v0.10.0/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
-github.com/crate-crypto/go-kzg-4844 v0.2.0 h1:UVuHOE+5tIWrim4zf/Xaa43+MIsDCPyW76QhUpiMGj4=
-github.com/crate-crypto/go-kzg-4844 v0.2.0/go.mod h1:SBP7ikXEgDnUPONgm33HtuDZEDtWa3L4QtN1ocJSEQ4=
+github.com/crate-crypto/go-kzg-4844 v0.3.0 h1:UBlWE0CgyFqqzTI+IFyCzA7A3Zw4iip6uzRv5NIXG0A=
+github.com/crate-crypto/go-kzg-4844 v0.3.0/go.mod h1:SBP7ikXEgDnUPONgm33HtuDZEDtWa3L4QtN1ocJSEQ4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
[v0.3.0](https://github.com/crate-crypto/go-kzg-4844/releases/tag/v0.3.0) switches precompile input's z and y to big endian according to https://github.com/ethereum/EIPs/pull/7020.