### PR TITLE
EIP-4844: parse transactions when not wrapped with blobs

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -643,9 +643,8 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 			return txpoolcfg.InitCodeTooLarge
 		}
 	}
-	isCancun := p.isCancun()
 	if txn.Type == types.BlobTxType {
-		if !isCancun {
+		if !p.isCancun() {
 			return txpoolcfg.TypeNotActivated
 		}
 		if txn.Creation {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -623,6 +623,18 @@ func (p *TxPool) validateTx(txn *types.TxSlot, isLocal bool, stateCache kvcache.
 			return txpoolcfg.InitCodeTooLarge
 		}
 	}
+	isCancun := false
+	if txn.Type == types.BlobTxType {
+		if !isCancun {
+			return txpoolcfg.TypeNotActivated
+		}
+		if txn.Creation {
+			return txpoolcfg.CreateBlobTxn
+		}
+		if txn.BlobCount == 0 {
+			return txpoolcfg.NoBlobs
+		}
+	}
 
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if !isLocal && uint256.NewInt(p.cfg.MinFeeCap).Cmp(&txn.FeeCap) == 1 {

--- a/txpool/pool_fuzz_test.go
+++ b/txpool/pool_fuzz_test.go
@@ -8,14 +8,12 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/ledgerwatch/erigon-lib/common"
-	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
-
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/u256"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
@@ -23,6 +21,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/erigon-lib/rlp"
+	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 	"github.com/ledgerwatch/erigon-lib/types"
 )
 
@@ -314,7 +313,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 
 		cfg := txpoolcfg.DefaultConfig
 		sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-		pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, log.New())
+		pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, log.New())
 		assert.NoError(err)
 		pool.senders.senderIDs = senderIDs
 		for addr, id := range senderIDs {
@@ -545,7 +544,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 		check(p2pReceived, types.TxSlots{}, "after_flush")
 		checkNotify(p2pReceived, types.TxSlots{}, "after_flush")
 
-		p2, err := New(ch, coreDB, txpoolcfg.DefaultConfig, sendersCache, *u256.N1, nil, log.New())
+		p2, err := New(ch, coreDB, txpoolcfg.DefaultConfig, sendersCache, *u256.N1, nil, nil, log.New())
 		assert.NoError(err)
 		p2.senders = pool.senders // senders are not persisted
 		err = coreDB.View(ctx, func(coreTx kv.Tx) error { return p2.fromDB(ctx, tx, coreTx) })

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -124,7 +124,7 @@ func TestNonceFromAddress(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(uint64(6), nonce)
 	}
-	// test too expencive tx
+	// test too expensive tx
 	{
 		var txSlots types.TxSlots
 		txSlot1 := &types.TxSlot{

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 Erigon contributors
+   Copyright 2021 The Erigon contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
-	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
+	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,8 +37,8 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
+	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 	"github.com/ledgerwatch/erigon-lib/types"
-	"github.com/ledgerwatch/log/v3"
 )
 
 func TestNonceFromAddress(t *testing.T) {
@@ -48,7 +48,7 @@ func TestNonceFromAddress(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, log.New())
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, log.New())
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()
@@ -168,7 +168,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, log.New())
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, log.New())
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()
@@ -285,7 +285,7 @@ func TestReverseNonces(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, log.New())
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, log.New())
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()
@@ -403,7 +403,7 @@ func TestReverseNonces(t *testing.T) {
 
 // When local transaction is send to the pool, but it cannot replace existing transaction,
 // the existing transaction gets "poked" and is getting re-broadcasted
-// this is a workaround for cases when transactions are getting stuck for strage reasons
+// this is a workaround for cases when transactions are getting stuck for strange reasons
 // even though logs show they are broadcast
 func TestTxPoke(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
@@ -412,7 +412,7 @@ func TestTxPoke(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, log.New())
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, nil, nil, log.New())
 	assert.NoError(err)
 	require.True(pool != nil)
 	ctx := context.Background()
@@ -677,7 +677,7 @@ func TestShanghaiValidateTx(t *testing.T) {
 			}
 
 			cache := &kvcache.DummyCache{}
-			pool, err := New(ch, coreDB, cfg, cache, *u256.N1, shanghaiTime, logger)
+			pool, err := New(ch, coreDB, cfg, cache, *u256.N1, shanghaiTime, nil /* cancunTime */, logger)
 			asrt.NoError(err)
 			ctx := context.Background()
 			tx, err := coreDB.BeginRw(ctx)

--- a/txpool/txpool_grpc_server.go
+++ b/txpool/txpool_grpc_server.go
@@ -240,7 +240,8 @@ func mapDiscardReasonToProto(reason txpoolcfg.DiscardReason) txpool_proto.Import
 		return txpool_proto.ImportResult_ALREADY_EXISTS
 	case txpoolcfg.UnderPriced, txpoolcfg.ReplaceUnderpriced, txpoolcfg.FeeTooLow:
 		return txpool_proto.ImportResult_FEE_TOO_LOW
-	case txpoolcfg.InvalidSender, txpoolcfg.NegativeValue, txpoolcfg.OversizedData, txpoolcfg.InitCodeTooLarge, txpoolcfg.RLPTooLong:
+	case txpoolcfg.InvalidSender, txpoolcfg.NegativeValue, txpoolcfg.OversizedData, txpoolcfg.InitCodeTooLarge, txpoolcfg.RLPTooLong, txpoolcfg.CreateBlobTxn, txpoolcfg.NoBlobs, txpoolcfg.TypeNotActivated:
+		// TODO(eip-4844) TypeNotActivated may be transient (e.g. a blob transaction is submitted 1 sec prior to Cancun activation)
 		return txpool_proto.ImportResult_INVALID
 	default:
 		return txpool_proto.ImportResult_INTERNAL_ERROR

--- a/txpool/txpoolcfg/txpoolcfg.go
+++ b/txpool/txpoolcfg/txpoolcfg.go
@@ -69,6 +69,9 @@ const (
 	NotReplaced         DiscardReason = 20 // There was an existing transaction with the same sender and nonce, not enough price bump to replace
 	DuplicateHash       DiscardReason = 21 // There was an existing transaction with the same hash
 	InitCodeTooLarge    DiscardReason = 22 // EIP-3860 - transaction init code is too large
+	TypeNotActivated    DiscardReason = 23 // For example, an EIP-4844 transaction is submitted before Cancun activation
+	CreateBlobTxn       DiscardReason = 24 // Blob transactions cannot have the form of a create transaction
+	NoBlobs             DiscardReason = 25 // Blob transactions must have at least one blob
 )
 
 func (r DiscardReason) String() string {
@@ -119,6 +122,12 @@ func (r DiscardReason) String() string {
 		return "existing tx with same hash"
 	case InitCodeTooLarge:
 		return "initcode too large"
+	case TypeNotActivated:
+		return "fork supporting this transaction type is not activated yet"
+	case CreateBlobTxn:
+		return "blob transactions cannot have the form of a create transaction"
+	case NoBlobs:
+		return "blob transactions must have at least one blob"
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}

--- a/txpool/txpooluitl/all_components.go
+++ b/txpool/txpooluitl/all_components.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 Erigon contributors
+   Copyright 2021 The Erigon contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/holiman/uint256"
-	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 	"github.com/ledgerwatch/log/v3"
 	mdbx2 "github.com/torquem-ch/mdbx-go/mdbx"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/txpool"
+	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 	"github.com/ledgerwatch/erigon-lib/types"
 )
 
@@ -123,8 +123,9 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, cache kvcache.Cach
 	if cfg.OverrideShanghaiTime != nil {
 		shanghaiTime = cfg.OverrideShanghaiTime
 	}
+	cancunTime := chainConfig.CancunTime
 
-	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, logger)
+	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, cancunTime, logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}

--- a/types/txn.go
+++ b/types/txn.go
@@ -251,7 +251,6 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	// Only note if To field is empty or not
 	slot.Creation = dataLen == 0
 	p = dataPos + dataLen
-
 	// Next follows value
 	p, err = rlp.U256(payload, p, &slot.Value)
 	if err != nil {

--- a/types/txn.go
+++ b/types/txn.go
@@ -91,15 +91,16 @@ type TxSlot struct {
 	Nonce          uint64      // Nonce of the transaction
 	DataLen        int         // Length of transaction's data (for calculation of intrinsic gas)
 	DataNonZeroLen int
-	AlAddrCount    int      // Number of addresses in the access list
-	AlStorCount    int      // Number of storage keys in the access list
-	BlobCount      uint64   // Number of blobs contained by the transaction
-	Gas            uint64   // Gas limit of the transaction
-	IDHash         [32]byte // Transaction hash for the purposes of using it as a transaction Id
-	Traced         bool     // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
-	Creation       bool     // Set to true if "To" field of the transaction is not set
-	Type           byte     // Transaction type
-	Size           uint32   // Size of the payload
+	AlAddrCount    int         // Number of addresses in the access list
+	AlStorCount    int         // Number of storage keys in the access list
+	BlobCount      uint64      // Number of blobs contained by the transaction
+	DataFeeCap     uint256.Int // max_fee_per_data_gas in EIP-4844
+	Gas            uint64      // Gas limit of the transaction
+	IDHash         [32]byte    // Transaction hash for the purposes of using it as a transaction Id
+	Traced         bool        // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
+	Creation       bool        // Set to true if "To" field of the transaction is not set
+	Type           byte        // Transaction type
+	Size           uint32      // Size of the payload
 }
 
 const (
@@ -128,8 +129,7 @@ func (ctx *TxParseContext) ChainIDRequired() *TxParseContext {
 // wrappedWithBlobs means that for blob (type 3) transactions the full version with blobs/commitments/proofs is expected
 // (see https://eips.ethereum.org/EIPS/eip-4844#networking).
 func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlot, sender []byte, hasEnvelope, wrappedWithBlobs bool, validateHash func([]byte) error) (p int, err error) {
-	// TODO(eip-4844) implement blob txn parsing with and w/o wrappedWithBlobs
-	// Ensure that TxSlot.BlobCount is properly populated
+	// TODO(eip-4844) implement blob txn parsing when wrappedWithBlobs is true
 
 	if len(payload) == 0 {
 		return 0, fmt.Errorf("%w: empty rlp", ErrParseTxn)
@@ -217,7 +217,6 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 		return 0, fmt.Errorf("%w: nonce: %s", ErrParseTxn, err) //nolint
 	}
 	// Next follows gas price or tip
-	// Although consensus rules specify that tip can be up to 256 bit long, we narrow it to 64 bit
 	p, err = rlp.U256(payload, p, &slot.Tip)
 	if err != nil {
 		return 0, fmt.Errorf("%w: tip: %s", ErrParseTxn, err) //nolint
@@ -227,7 +226,6 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	if slot.Type < DynamicFeeTxType {
 		slot.FeeCap = slot.Tip
 	} else {
-		// Although consensus rules specify that feeCap can be up to 256 bit long, we narrow it to 64 bit
 		p, err = rlp.U256(payload, p, &slot.FeeCap)
 		if err != nil {
 			return 0, fmt.Errorf("%w: feeCap: %s", ErrParseTxn, err) //nolint
@@ -249,7 +247,11 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 
 	// Only note if To field is empty or not
 	slot.Creation = dataLen == 0
+	if slot.Creation && slot.Type == BlobTxType {
+		return 0, fmt.Errorf("%w: blob transactions cannot have the form of a create transaction", ErrParseTxn)
+	}
 	p = dataPos + dataLen
+
 	// Next follows value
 	p, err = rlp.U256(payload, p, &slot.Value)
 	if err != nil {
@@ -279,8 +281,8 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 			return 0, fmt.Errorf("%w: access list len: %s", ErrParseTxn, err) //nolint
 		}
 		tuplePos := dataPos
-		var tupleLen int
 		for tuplePos < dataPos+dataLen {
+			var tupleLen int
 			tuplePos, tupleLen, err = rlp.List(payload, tuplePos)
 			if err != nil {
 				return 0, fmt.Errorf("%w: tuple len: %s", ErrParseTxn, err) //nolint
@@ -314,6 +316,32 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 			return 0, fmt.Errorf("%w: extraneous space in the access list after all tuples", ErrParseTxn)
 		}
 		p = dataPos + dataLen
+	}
+	if slot.Type == BlobTxType {
+		p, err = rlp.U256(payload, p, &slot.DataFeeCap)
+		if err != nil {
+			return 0, fmt.Errorf("%w: data fee cap: %s", ErrParseTxn, err) //nolint
+		}
+		dataPos, dataLen, err = rlp.List(payload, p)
+		if err != nil {
+			return 0, fmt.Errorf("%w: blob hashes len: %s", ErrParseTxn, err) //nolint
+		}
+		hashPos := dataPos
+		for hashPos < dataPos+dataLen {
+			hashPos, err = rlp.StringOfLen(payload, hashPos, 32)
+			if err != nil {
+				return 0, fmt.Errorf("%w: blob hash: %s", ErrParseTxn, err) //nolint
+			}
+			slot.BlobCount++
+			hashPos += 32
+		}
+		if hashPos != dataPos+dataLen {
+			return 0, fmt.Errorf("%w: extraneous space in the blob versioned hashes", ErrParseTxn)
+		}
+		p = dataPos + dataLen
+		if slot.BlobCount == 0 {
+			return 0, fmt.Errorf("%w: there must be at least one blob", ErrParseTxn)
+		}
 	}
 	// This is where the data for Sighash ends
 	// Next follows V of the signature


### PR DESCRIPTION
Implement `ParseTransaction` when `wrappedWithBlobs` is false. (The `wrappedWithBlobs` case is still to be implemented).