### PR TITLE
add map size setter

### DIFF
--- a/txpool/txpooluitl/all_components.go
+++ b/txpool/txpooluitl/all_components.go
@@ -105,6 +105,7 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, cache kvcache.Cach
 	txPoolDB, err := mdbx.NewMDBX(log.New()).Label(kv.TxPoolDB).Path(cfg.DBDir).
 		WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg { return kv.TxpoolTablesCfg }).
 		Flags(func(f uint) uint { return f ^ mdbx2.Durable | mdbx2.SafeNoSync }).
+		MapSize(512 * datasize.MB).
 		GrowthStep(16 * datasize.MB).
 		SyncPeriod(30 * time.Second).
 		Open()


### PR DESCRIPTION
Add a bound the txpool db, rather than leaving it as the default of 2TB.  This is to reduce the page file profile when running multiple nodes from around 3.5GB per txpool instance.   

The current pool map side is set to 512MB - which seems reasonable with 16MB increments