### PR TITLE
Revert "add map size setter"

### DIFF
--- a/txpool/txpooluitl/all_components.go
+++ b/txpool/txpooluitl/all_components.go
@@ -105,7 +105,6 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, cache kvcache.Cach
 	txPoolDB, err := mdbx.NewMDBX(log.New()).Label(kv.TxPoolDB).Path(cfg.DBDir).
 		WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg { return kv.TxpoolTablesCfg }).
 		Flags(func(f uint) uint { return f ^ mdbx2.Durable | mdbx2.SafeNoSync }).
-		MapSize(512 * datasize.MB).
 		GrowthStep(16 * datasize.MB).
 		SyncPeriod(30 * time.Second).
 		Open()


### PR DESCRIPTION
Reverts ledgerwatch/erigon-lib#1050

It causes the error:

`EROR[07-21|21:45:02.806] [txpool] flush is local history          err="table: PoolTransaction, err: mdbx_cursor_put: MDBX_MAP_FULL: Environment mapsize limit reached"
`