### PR TITLE
Fix blob transaction panic in txpool

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -1532,17 +1532,17 @@ func MainLoop(ctx context.Context, db kv.RwDB, coreDB kv.RoDB, p *TxPool, newTxs
 						// Empty rlp can happen if a transaction we want to broadcast has just been mined, for example
 						slotsRlp = append(slotsRlp, slotRlp)
 						if p.IsLocal(hash) {
-							localTxTypes = append(localTxTypes, t)
-							localTxSizes = append(localTxSizes, size)
-							localTxHashes = append(localTxHashes, hash...)
 							if t != types.BlobTxType { // "Nodes MUST NOT automatically broadcast blob transactions to their peers" - EIP-4844
+								localTxTypes = append(localTxTypes, t)
+								localTxSizes = append(localTxSizes, size)
+								localTxHashes = append(localTxHashes, hash...)
 								localTxRlps = append(localTxRlps, slotRlp)
 							}
 						} else {
-							remoteTxTypes = append(remoteTxTypes, t)
-							remoteTxSizes = append(remoteTxSizes, size)
-							remoteTxHashes = append(remoteTxHashes, hash...)
 							if t != types.BlobTxType { // "Nodes MUST NOT automatically broadcast blob transactions to their peers" - EIP-4844
+								remoteTxTypes = append(remoteTxTypes, t)
+								remoteTxSizes = append(remoteTxSizes, size)
+								remoteTxHashes = append(remoteTxHashes, hash...)
 								remoteTxRlps = append(remoteTxRlps, slotRlp)
 							}
 						}


### PR DESCRIPTION
Fixes the following panic triggered by blob Hive tests:
```
[2c098836] panic: runtime error: index out of range [0] with length 0
[2c098836] 
[2c098836] goroutine 902 [running]:
[2c098836] github.com/ledgerwatch/erigon-lib/txpool.MainLoop.func1()
[2c098836] 	github.com/ledgerwatch/erigon-lib@v0.0.0-20230801100033-1b342f37741d/txpool/pool.go:1565 +0x100f
[2c098836] created by github.com/ledgerwatch/erigon-lib/txpool.MainLoop
[2c098836] 	github.com/ledgerwatch/erigon-lib@v0.0.0-20230801100033-1b342f37741d/txpool/pool.go:1492 +0x8c5
```