### PR TITLE
Reduce SyncToNewPeersEvery

### DIFF
--- a/txpool/txpoolcfg/txpoolcfg.go
+++ b/txpool/txpoolcfg/txpoolcfg.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	SyncToNewPeersEvery:   2 * time.Minute,
+	SyncToNewPeersEvery:   5 * time.Second,
 	ProcessRemoteTxsEvery: 100 * time.Millisecond,
 	CommitEvery:           15 * time.Second,
 	LogEvery:              30 * time.Second,


### PR DESCRIPTION
The default 2 min SyncToNewPeersEvery seems like too big a value for txn propagation. So, changing the default to something like 5 sec w/o introducing a flag.